### PR TITLE
Refactor Result Handling

### DIFF
--- a/CVision.BLL/Commands/Publications/Delete/DeletePublicationCommand.cs
+++ b/CVision.BLL/Commands/Publications/Delete/DeletePublicationCommand.cs
@@ -1,7 +1,7 @@
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Commands.Publications.Delete;
 
 public record DeletePublicationCommand(int PublicationId, int UserId)
-    : IRequest<Result>;
+    : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/Publications/Delete/DeletePublicationHandler.cs
+++ b/CVision.BLL/Commands/Publications/Delete/DeletePublicationHandler.cs
@@ -1,15 +1,15 @@
 using CVision.BLL.Constans;
+using CVision.BLL.Helpers;
 using CVision.DAL.Repositories.Interfaces.Base;
 using CVision.DAL.Repositories.Options;
-using FluentResults;
 using MediatR;
 
 namespace CVision.BLL.Commands.Publications.Delete;
 
 public class DeletePublicationHandler(
-    IRepositoryWrapper repositoryWrapper) : IRequestHandler<DeletePublicationCommand, Result>
+    IRepositoryWrapper repositoryWrapper) : IRequestHandler<DeletePublicationCommand, Result<bool>>
 {
-    public async Task<Result> Handle(
+    public async Task<Result<bool>> Handle(
         DeletePublicationCommand request,
         CancellationToken cancellationToken)
     {
@@ -22,21 +22,21 @@ public class DeletePublicationHandler(
 
         if (publication is null)
         {
-            return Result.Fail(PublicationsConstants.PublicationNotFound);
+            return PublicationsConstants.PublicationNotFound;
         }
 
         if (publication.UserId != request.UserId)
         {
-            return Result.Fail("Unauthorized");
+            return "Unauthorized";
         }
 
         repositoryWrapper.PublicationRepository.Delete(publication);
 
         if (await repositoryWrapper.SaveChangesAsync() <= 0)
         {
-            return Result.Fail(PublicationsConstants.PublicationDeleteError);
+            return PublicationsConstants.PublicationDeleteError;
         }
 
-        return Result.Ok();
+        return true;
     }
 }

--- a/CVision.BLL/Commands/Publications/Update/UpdatePublicationCommand.cs
+++ b/CVision.BLL/Commands/Publications/Update/UpdatePublicationCommand.cs
@@ -1,8 +1,8 @@
 using CVision.BLL.DTOs.Publications;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Commands.Publications.Update;
 
 public record UpdatePublicationCommand(int PublicationId, int UserId, UpdatePublicationRequestDto RequestDto)
-    : IRequest<Result>;
+    : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/Publications/Update/UpdatePublicationHandler.cs
+++ b/CVision.BLL/Commands/Publications/Update/UpdatePublicationHandler.cs
@@ -1,7 +1,7 @@
 using CVision.BLL.Constans;
+using CVision.BLL.Helpers;
 using CVision.DAL.Repositories.Interfaces.Base;
 using CVision.DAL.Repositories.Options;
-using FluentResults;
 using FluentValidation;
 using MediatR;
 
@@ -9,9 +9,9 @@ namespace CVision.BLL.Commands.Publications.Update;
 
 public class UpdatePublicationHandler(
     IRepositoryWrapper repositoryWrapper,
-    IValidator<UpdatePublicationCommand> validator) : IRequestHandler<UpdatePublicationCommand, Result>
+    IValidator<UpdatePublicationCommand> validator) : IRequestHandler<UpdatePublicationCommand, Result<bool>>
 {
-    public async Task<Result> Handle(
+    public async Task<Result<bool>> Handle(
         UpdatePublicationCommand request,
         CancellationToken cancellationToken)
     {
@@ -19,7 +19,7 @@ public class UpdatePublicationHandler(
 
         if (!validationResult.IsValid)
         {
-            return Result.Fail(validationResult.Errors.First().ErrorMessage);
+            return validationResult.Errors.First().ErrorMessage;
         }
 
         var publication = await repositoryWrapper.PublicationRepository.GetFirstOrDefaultAsync(
@@ -31,12 +31,12 @@ public class UpdatePublicationHandler(
 
         if (publication is null)
         {
-            return Result.Fail(PublicationsConstants.PublicationNotFound);
+            return PublicationsConstants.PublicationNotFound;
         }
 
         if (publication.UserId != request.UserId)
         {
-            return Result.Fail("Unauthorized");
+            return "Unauthorized";
         }
 
         publication.Title = request.RequestDto.Title;
@@ -46,9 +46,9 @@ public class UpdatePublicationHandler(
 
         if (await repositoryWrapper.SaveChangesAsync() <= 0)
         {
-            return Result.Fail(PublicationsConstants.PublicationUpdateError);
+            return PublicationsConstants.PublicationUpdateError;
         }
 
-        return Result.Ok();
+        return true;
     }
 }

--- a/CVision.BLL/Commands/Users/ConfirmEmail/ConfirmEmailCommand.cs
+++ b/CVision.BLL/Commands/Users/ConfirmEmail/ConfirmEmailCommand.cs
@@ -1,10 +1,8 @@
 using CVision.BLL.DTOs.Users;
+using CVision.BLL.Helpers;
 using MediatR;
-using FluentResults;
 
 namespace CVision.BLL.Commands.Users.ConfirmEmail;
 
 public record ConfirmEmailCommand(ConfirmEmailRequestDto RequestDto)
-    : IRequest<Result>
-{
-}
+    : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/Users/ConfirmEmail/ConfirmEmailHandler.cs
+++ b/CVision.BLL/Commands/Users/ConfirmEmail/ConfirmEmailHandler.cs
@@ -1,12 +1,12 @@
-using MediatR;
-using FluentResults;
-using CVision.DAL.Entities;
 using CVision.BLL.Constans;
+using CVision.BLL.Helpers;
+using CVision.DAL.Entities;
+using MediatR;
 using Microsoft.AspNetCore.Identity;
 
 namespace CVision.BLL.Commands.Users.ConfirmEmail;
 
-public class ConfirmEmailHandler : IRequestHandler<ConfirmEmailCommand, Result>
+public class ConfirmEmailHandler : IRequestHandler<ConfirmEmailCommand, Result<bool>>
 {
     private readonly UserManager<ApplicationUser> _userManager;
 
@@ -15,21 +15,21 @@ public class ConfirmEmailHandler : IRequestHandler<ConfirmEmailCommand, Result>
         _userManager = userManager;
     }
 
-    public async Task<Result> Handle(ConfirmEmailCommand request, CancellationToken cancellationToken)
+    public async Task<Result<bool>> Handle(ConfirmEmailCommand request, CancellationToken cancellationToken)
     {
         ApplicationUser? user = await _userManager.FindByIdAsync(request.RequestDto.UserId.ToString());
         if (user == null)
         {
-            return Result.Fail(UserConstants.UserNotFound);
+            return UserConstants.UserNotFound;
         }
 
         var result = await _userManager.ConfirmEmailAsync(user, request.RequestDto.Token);
 
         if (!result.Succeeded)
         {
-            return Result.Fail(UserConstants.EmailConfirmationError);
+            return UserConstants.EmailConfirmationError;
         }
 
-        return Result.Ok();
+        return true;
     }
 }

--- a/CVision.BLL/Commands/Users/ForgotPassword/ForgotPasswordCommand.cs
+++ b/CVision.BLL/Commands/Users/ForgotPassword/ForgotPasswordCommand.cs
@@ -1,8 +1,8 @@
 using CVision.BLL.DTOs.Users;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Commands.Users.ForgotPassword;
 
 public record ForgotPasswordCommand(ForgotPasswordRequestDto RequestDto)
-    : IRequest<Result>;
+    : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/Users/ForgotPassword/ForgotPasswordHandler.cs
+++ b/CVision.BLL/Commands/Users/ForgotPassword/ForgotPasswordHandler.cs
@@ -1,13 +1,13 @@
+using CVision.BLL.Helpers;
 using CVision.BLL.Interfaces;
 using CVision.DAL.Entities;
-using FluentResults;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 
 namespace CVision.BLL.Commands.Users.ForgotPassword;
 
-public class ForgotPasswordHandler : IRequestHandler<ForgotPasswordCommand, Result>
+public class ForgotPasswordHandler : IRequestHandler<ForgotPasswordCommand, Result<bool>>
 {
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IEmailService _emailService;
@@ -23,13 +23,13 @@ public class ForgotPasswordHandler : IRequestHandler<ForgotPasswordCommand, Resu
         _configuration = configuration;
     }
 
-    public async Task<Result> Handle(ForgotPasswordCommand request, CancellationToken cancellationToken)
+    public async Task<Result<bool>> Handle(ForgotPasswordCommand request, CancellationToken cancellationToken)
     {
         var user = await _userManager.FindByEmailAsync(request.RequestDto.Email);
 
         if (user == null)
         {
-            return Result.Ok();
+            return true;
         }
 
         var token = await _userManager.GeneratePasswordResetTokenAsync(user);
@@ -39,6 +39,6 @@ public class ForgotPasswordHandler : IRequestHandler<ForgotPasswordCommand, Resu
 
         await _emailService.SendPasswordResetEmailAsync(user.Email!, resetLink);
 
-        return Result.Ok();
+        return true;
     }
 }

--- a/CVision.BLL/Commands/Users/Login/LoginUserCommand.cs
+++ b/CVision.BLL/Commands/Users/Login/LoginUserCommand.cs
@@ -1,6 +1,6 @@
 using CVision.BLL.DTOs.Users;
 using CVision.DAL.Entities;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Commands.Users.Login;

--- a/CVision.BLL/Commands/Users/Login/LoginUserHandler.cs
+++ b/CVision.BLL/Commands/Users/Login/LoginUserHandler.cs
@@ -1,6 +1,6 @@
 using CVision.BLL.Constans;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
-using FluentResults;
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
@@ -20,28 +20,28 @@ public class LoginUserHandler(
 
         if (!validationResult.IsValid)
         {
-            return Result.Fail<ApplicationUser>(validationResult.Errors.First().ErrorMessage);
+            return validationResult.Errors.First().ErrorMessage;
         }
 
         var user = await userManager.FindByEmailAsync(request.RequestDto.Email);
 
         if (user is null)
         {
-            return Result.Fail<ApplicationUser>(UserConstants.UserLogInError);
+            return UserConstants.UserLogInError;
         }
 
         var passwordValid = await userManager.CheckPasswordAsync(user, request.RequestDto.Password);
 
         if (!passwordValid)
         {
-            return Result.Fail<ApplicationUser>(UserConstants.UserLogInError);
+            return UserConstants.UserLogInError;
         }
 
         if (!user.EmailConfirmed)
         {
-            return Result.Fail<ApplicationUser>(UserConstants.UserLogInError);
+            return UserConstants.UserLogInError;
         }
 
-        return Result.Ok(user);
+        return user;
     }
 }

--- a/CVision.BLL/Commands/Users/Register/RegisterUserCommand.cs
+++ b/CVision.BLL/Commands/Users/Register/RegisterUserCommand.cs
@@ -1,4 +1,4 @@
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 using CVision.BLL.DTOs.Users;
 

--- a/CVision.BLL/Commands/Users/Register/RegisterUserHandler.cs
+++ b/CVision.BLL/Commands/Users/Register/RegisterUserHandler.cs
@@ -2,7 +2,7 @@ using AutoMapper;
 using CVision.BLL.DTOs.Users;
 using CVision.BLL.Interfaces;
 using CVision.DAL.Entities;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 using FluentValidation;
 using Microsoft.AspNetCore.Identity;
@@ -37,7 +37,7 @@ public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<R
 
         if (!validationResult.IsValid)
         {
-            return Result.Fail<RegisterUserResponseDto>(validationResult.Errors.First().ErrorMessage);
+            return validationResult.Errors.First().ErrorMessage;
         }
 
         ApplicationUser newUser = _mapper.Map<ApplicationUser>(request.RequestDto);
@@ -46,7 +46,7 @@ public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<R
 
         if (!identityResult.Succeeded)
         {
-            return Result.Fail<RegisterUserResponseDto>(identityResult.Errors.Select(e => e.Description));
+            return string.Join("; ", identityResult.Errors.Select(e => e.Description));
         }
 
         var emailToken = await _userManager.GenerateEmailConfirmationTokenAsync(newUser);
@@ -56,6 +56,6 @@ public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<R
         await _emailService.SendConfirmationEmailAsync(newUser.Email!, confirmationLink);
 
         var responseDto = _mapper.Map<RegisterUserResponseDto>(newUser);
-        return Result.Ok(responseDto);
+        return responseDto;
     }
 }

--- a/CVision.BLL/Commands/Users/ResetPassword/ResetPasswordCommand.cs
+++ b/CVision.BLL/Commands/Users/ResetPassword/ResetPasswordCommand.cs
@@ -1,8 +1,8 @@
 using CVision.BLL.DTOs.Users;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Commands.Users.ResetPassword;
 
 public record ResetPasswordCommand(ResetPasswordRequestDto RequestDto)
-    : IRequest<Result>;
+    : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/Users/ResetPassword/ResetPasswordHandler.cs
+++ b/CVision.BLL/Commands/Users/ResetPassword/ResetPasswordHandler.cs
@@ -1,12 +1,12 @@
 using CVision.BLL.Constans;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
-using FluentResults;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 
 namespace CVision.BLL.Commands.Users.ResetPassword;
 
-public class ResetPasswordHandler : IRequestHandler<ResetPasswordCommand, Result>
+public class ResetPasswordHandler : IRequestHandler<ResetPasswordCommand, Result<bool>>
 {
     private readonly UserManager<ApplicationUser> _userManager;
 
@@ -15,12 +15,12 @@ public class ResetPasswordHandler : IRequestHandler<ResetPasswordCommand, Result
         _userManager = userManager;
     }
 
-    public async Task<Result> Handle(ResetPasswordCommand request, CancellationToken cancellationToken)
+    public async Task<Result<bool>> Handle(ResetPasswordCommand request, CancellationToken cancellationToken)
     {
         var user = await _userManager.FindByEmailAsync(request.RequestDto.Email);
         if (user == null)
         {
-            return Result.Fail(UserConstants.PasswordResetError);
+            return UserConstants.PasswordResetError;
         }
 
         var result = await _userManager.ResetPasswordAsync(
@@ -28,9 +28,9 @@ public class ResetPasswordHandler : IRequestHandler<ResetPasswordCommand, Result
 
         if (!result.Succeeded)
         {
-            return Result.Fail(result.Errors.Select(e => e.Description));
+            return string.Join("; ", result.Errors.Select(e => e.Description));
         }
 
-        return Result.Ok();
+        return true;
     }
 }

--- a/CVision.BLL/Commands/Users/UpdatePassword/UpdatePasswordCommand.cs
+++ b/CVision.BLL/Commands/Users/UpdatePassword/UpdatePasswordCommand.cs
@@ -1,8 +1,8 @@
 using CVision.BLL.DTOs.Users;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Commands.Users.UpdatePassword;
 
 public record UpdatePasswordCommand(int UserId, UpdatePasswordRequestDto RequestDto)
-    : IRequest<Result>;
+    : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/Users/UpdatePassword/UpdatePasswordHandler.cs
+++ b/CVision.BLL/Commands/Users/UpdatePassword/UpdatePasswordHandler.cs
@@ -1,12 +1,12 @@
 using CVision.BLL.Constans;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
-using FluentResults;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 
 namespace CVision.BLL.Commands.Users.UpdatePassword;
 
-public class UpdatePasswordHandler : IRequestHandler<UpdatePasswordCommand, Result>
+public class UpdatePasswordHandler : IRequestHandler<UpdatePasswordCommand, Result<bool>>
 {
     private readonly UserManager<ApplicationUser> _userManager;
 
@@ -15,12 +15,12 @@ public class UpdatePasswordHandler : IRequestHandler<UpdatePasswordCommand, Resu
         _userManager = userManager;
     }
 
-    public async Task<Result> Handle(UpdatePasswordCommand request, CancellationToken cancellationToken)
+    public async Task<Result<bool>> Handle(UpdatePasswordCommand request, CancellationToken cancellationToken)
     {
         var user = await _userManager.FindByIdAsync(request.UserId.ToString());
         if (user == null)
         {
-            return Result.Fail(UserConstants.UserNotFound);
+            return UserConstants.UserNotFound;
         }
 
         var result = await _userManager.ChangePasswordAsync(
@@ -31,12 +31,12 @@ public class UpdatePasswordHandler : IRequestHandler<UpdatePasswordCommand, Resu
             var errors = result.Errors.Select(e => e.Description).ToList();
             if (errors.Any(e => e.Contains("incorrect", StringComparison.OrdinalIgnoreCase)))
             {
-                return Result.Fail(UserConstants.IncorrectCurrentPassword);
+                return UserConstants.IncorrectCurrentPassword;
             }
 
-            return Result.Fail(errors);
+            return string.Join("; ", errors);
         }
 
-        return Result.Ok();
+        return true;
     }
 }

--- a/CVision.BLL/Commands/Users/UpdateProfile/UpdateProfileCommand.cs
+++ b/CVision.BLL/Commands/Users/UpdateProfile/UpdateProfileCommand.cs
@@ -1,5 +1,5 @@
 using CVision.BLL.DTOs.Users;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Commands.Users.UpdateProfile;

--- a/CVision.BLL/Commands/Users/UpdateProfile/UpdateProfileHandler.cs
+++ b/CVision.BLL/Commands/Users/UpdateProfile/UpdateProfileHandler.cs
@@ -3,7 +3,7 @@ using CVision.BLL.Constans;
 using CVision.BLL.DTOs.Users;
 using CVision.BLL.Interfaces;
 using CVision.DAL.Entities;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 
@@ -19,7 +19,7 @@ public class UpdateProfileHandler(
         var user = await userManager.FindByIdAsync(request.UserId.ToString());
         if (user == null)
         {
-            return Result.Fail<GetUserResponseDto>(UserConstants.UserNotFound);
+            return UserConstants.UserNotFound;
         }
 
         user.UserName = request.RequestDto.UserName;
@@ -31,7 +31,7 @@ public class UpdateProfileHandler(
             var existingUser = await userManager.FindByEmailAsync(request.RequestDto.Email);
             if (existingUser != null && existingUser.Id != user.Id)
             {
-                return Result.Fail<GetUserResponseDto>(UserConstants.EmailAlreadyInUse);
+                return UserConstants.EmailAlreadyInUse;
             }
 
             user.Email = request.RequestDto.Email;
@@ -42,8 +42,7 @@ public class UpdateProfileHandler(
         var result = await userManager.UpdateAsync(user);
         if (!result.Succeeded)
         {
-            var errors = result.Errors.Select(e => e.Description).ToList();
-            return Result.Fail<GetUserResponseDto>(errors);
+            return string.Join("; ", result.Errors.Select(e => e.Description));
         }
 
         if (emailChanged)
@@ -54,6 +53,6 @@ public class UpdateProfileHandler(
         }
 
         var response = mapper.Map<GetUserResponseDto>(user);
-        return Result.Ok(response);
+        return response;
     }
 }

--- a/CVision.BLL/Helpers/Result.cs
+++ b/CVision.BLL/Helpers/Result.cs
@@ -23,4 +23,6 @@ public class Result<T>
     public static implicit operator Result<T>(T value) => new(value);
 
     public static implicit operator Result<T>(string error) => new(error);
+
+    public static Result<T> Ok(T value) => new(value);
 }

--- a/CVision.BLL/Queries/CvAnalyses/GetAllCvAnalyses/GetAllByUserIdHandler.cs
+++ b/CVision.BLL/Queries/CvAnalyses/GetAllCvAnalyses/GetAllByUserIdHandler.cs
@@ -1,7 +1,7 @@
 using AutoMapper;
 using CVision.BLL.DTOs.CvAnalyses;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
-using FluentResults;
 using CVision.DAL.Repositories.Interfaces.Base;
 using CVision.DAL.Repositories.Options;
 using MediatR;
@@ -25,6 +25,6 @@ public class GetAllByUserIdHandler(IMapper mapper, IRepositoryWrapper repository
 
         var result = mapper.Map<IEnumerable<CvAnalysisResponseShortDto>>(cvAnalyses);
 
-        return Result.Ok(result);
+        return Result<IEnumerable<CvAnalysisResponseShortDto>>.Ok(result);
     }
 }

--- a/CVision.BLL/Queries/CvAnalyses/GetAllCvAnalyses/GetAllByUserIdQuery.cs
+++ b/CVision.BLL/Queries/CvAnalyses/GetAllCvAnalyses/GetAllByUserIdQuery.cs
@@ -1,5 +1,5 @@
 using CVision.BLL.DTOs.CvAnalyses;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Queries.CvAnalyses.GetAllCvAnalyses;

--- a/CVision.BLL/Queries/Publications/GetAllPublications/GetAllPublicationsHandler.cs
+++ b/CVision.BLL/Queries/Publications/GetAllPublications/GetAllPublicationsHandler.cs
@@ -1,10 +1,10 @@
 using AutoMapper;
-using FluentResults;
-using MediatR;
 using CVision.BLL.DTOs.Publications;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
 using CVision.DAL.Repositories.Interfaces.Base;
 using CVision.DAL.Repositories.Options;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace CVision.BLL.Queries.Publications.GetAllPublications;
@@ -27,6 +27,6 @@ public class GetAllPublicationsHandler(
 
         var response = mapper.Map<IEnumerable<PublicationResponseShortDto>>(publications);
 
-        return Result.Ok(response);
+        return Result<IEnumerable<PublicationResponseShortDto>>.Ok(response);
     }
 }

--- a/CVision.BLL/Queries/Publications/GetAllPublications/GetAllPublicationsQuery.cs
+++ b/CVision.BLL/Queries/Publications/GetAllPublications/GetAllPublicationsQuery.cs
@@ -1,10 +1,8 @@
 using CVision.BLL.DTOs.Publications;
+using CVision.BLL.Helpers;
 using MediatR;
-using FluentResults;
 
 namespace CVision.BLL.Queries.Publications.GetAllPublications;
 
 public record GetAllPublicationsQuery()
-    : IRequest<Result<IEnumerable<PublicationResponseShortDto>>>
-{
-}
+    : IRequest<Result<IEnumerable<PublicationResponseShortDto>>>;

--- a/CVision.BLL/Queries/Publications/GetByPublicationId/GetPublicationByIdHandler.cs
+++ b/CVision.BLL/Queries/Publications/GetByPublicationId/GetPublicationByIdHandler.cs
@@ -1,10 +1,10 @@
-using MediatR;
 using AutoMapper;
-using FluentResults;
 using CVision.BLL.DTOs.Publications;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
 using CVision.DAL.Repositories.Interfaces.Base;
 using CVision.DAL.Repositories.Options;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace CVision.BLL.Queries.Publications.GetByPublicationId;
@@ -27,6 +27,6 @@ public class GetPublicationByIdHandler(IRepositoryWrapper repositoryWrapper, IMa
 
         var response = mapper.Map<PublicationResponseShortDto>(publications);
 
-        return Result.Ok(response);
+        return response;
     }
 }

--- a/CVision.BLL/Queries/Publications/GetByPublicationId/GetPublicationByIdQuery.cs
+++ b/CVision.BLL/Queries/Publications/GetByPublicationId/GetPublicationByIdQuery.cs
@@ -1,5 +1,5 @@
 using CVision.BLL.DTOs.Publications;
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 
 namespace CVision.BLL.Queries.Publications.GetByPublicationId;

--- a/CVision.BLL/Queries/Publications/GetByUserId/GetByUserIdHandler.cs
+++ b/CVision.BLL/Queries/Publications/GetByUserId/GetByUserIdHandler.cs
@@ -1,10 +1,10 @@
 using AutoMapper;
-using FluentResults;
-using MediatR;
 using CVision.BLL.DTOs.Publications;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
 using CVision.DAL.Repositories.Interfaces.Base;
 using CVision.DAL.Repositories.Options;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace CVision.BLL.Queries.Publications.GetByUserId;
@@ -28,6 +28,6 @@ public class GetByUserIdHandler(
 
         var response = mapper.Map<IEnumerable<PublicationResponseShortDto>>(publications);
 
-        return Result.Ok(response);
+        return Result<IEnumerable<PublicationResponseShortDto>>.Ok(response);
     }
 }

--- a/CVision.BLL/Queries/Publications/GetByUserId/GetByUserIdQuery.cs
+++ b/CVision.BLL/Queries/Publications/GetByUserId/GetByUserIdQuery.cs
@@ -1,10 +1,8 @@
 using CVision.BLL.DTOs.Publications;
+using CVision.BLL.Helpers;
 using MediatR;
-using FluentResults;
 
 namespace CVision.BLL.Queries.Publications.GetByUserId;
 
 public record GetByUserIdQuery(int UserId)
-    : IRequest<Result<IEnumerable<PublicationResponseShortDto>>>
-{
-}
+    : IRequest<Result<IEnumerable<PublicationResponseShortDto>>>;

--- a/CVision.BLL/Queries/Users/GetUserById/GetUserByIdHandler.cs
+++ b/CVision.BLL/Queries/Users/GetUserById/GetUserByIdHandler.cs
@@ -1,9 +1,9 @@
 using AutoMapper;
 using CVision.BLL.Constans;
-using MediatR;
-using FluentResults;
 using CVision.BLL.DTOs.Users;
+using CVision.BLL.Helpers;
 using CVision.DAL.Entities;
+using MediatR;
 using Microsoft.AspNetCore.Identity;
 
 namespace CVision.BLL.Queries.Users.GetUserById;
@@ -25,11 +25,11 @@ public class GetUserByIdHandler : IRequestHandler<GetUserByIdQuery, Result<GetUs
 
         if (user == null)
         {
-            return Result.Fail<GetUserResponseDto>(UserConstants.UserNotFound);
+            return UserConstants.UserNotFound;
         }
 
         var response = _mapper.Map<GetUserResponseDto>(user);
 
-        return Result.Ok(response);
+        return response;
     }
 }

--- a/CVision.BLL/Queries/Users/GetUserById/GetUserByIdQuery.cs
+++ b/CVision.BLL/Queries/Users/GetUserById/GetUserByIdQuery.cs
@@ -1,6 +1,6 @@
 using CVision.BLL.DTOs.Users;
+using CVision.BLL.Helpers;
 using MediatR;
-using FluentResults;
 
 namespace CVision.BLL.Queries.Users.GetUserById;
 

--- a/CVision/Controllers/AccountController.cs
+++ b/CVision/Controllers/AccountController.cs
@@ -49,7 +49,7 @@ namespace CVision.Controllers
                 return RedirectToAction(nameof(RegistrationConfirmed), new { isConfirmed = true });
             }
 
-            string errorMessage = TranslateErrorToUkrainian(result.Errors.FirstOrDefault()?.Message)
+            string errorMessage = TranslateErrorToUkrainian(result.Error)
                 ?? "Не вдалося підтвердити email. Спробуйте ще раз.";
 
             return RedirectToAction(nameof(RegistrationConfirmed), new { isConfirmed = false, errorMessage });
@@ -84,20 +84,17 @@ namespace CVision.Controllers
 
                 if (response.IsSuccess)
                 {
-                    await signInManager.SignInAsync(response.Value, isPersistent: false);
+                    await signInManager.SignInAsync(response.Value!, isPersistent: false);
                     return RedirectToAction("hub", "Home");
                 }
 
-                if (!response.Errors.Any())
+                if (response.Error == null)
                 {
                     ModelState.AddModelError(string.Empty, "Не вдалося увійти. Перевірте email та пароль.");
                     return View(model);
                 }
 
-                foreach (var error in response.Errors)
-                {
-                    ModelState.AddModelError(string.Empty, TranslateErrorToUkrainian(error.Message));
-                }
+                ModelState.AddModelError(string.Empty, TranslateErrorToUkrainian(response.Error));
 
                 return View(model);
             }
@@ -204,9 +201,9 @@ namespace CVision.Controllers
                 return RedirectToAction(nameof(Login));
             }
 
-            foreach (var error in result.Errors)
+            if (result.Error != null)
             {
-                ModelState.AddModelError(string.Empty, TranslateErrorToUkrainian(error.Message));
+                ModelState.AddModelError(string.Empty, TranslateErrorToUkrainian(result.Error));
             }
 
             return View(model);
@@ -233,18 +230,15 @@ namespace CVision.Controllers
             {
                 var response = await mediator.Send(new RegisterUserCommand(requestDto));
 
-                if (response.IsFailed)
+                if (!response.IsSuccess)
                 {
-                    if (!response.Errors.Any())
+                    if (response.Error == null)
                     {
                         ModelState.AddModelError(string.Empty, "Не вдалося зареєструвати акаунт.");
                         return View(model);
                     }
 
-                    foreach (var error in response.Errors)
-                    {
-                        ModelState.AddModelError(string.Empty, TranslateErrorToUkrainian(error.Message));
-                    }
+                    ModelState.AddModelError(string.Empty, TranslateErrorToUkrainian(response.Error));
 
                     return View(model);
                 }

--- a/CVision/Controllers/ApiControllers/AuthController.cs
+++ b/CVision/Controllers/ApiControllers/AuthController.cs
@@ -10,7 +10,6 @@ using CVision.DAL.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using FluentResults;
 using System.Security.Claims;
 
 namespace CVision.Controllers.ApiControllers;
@@ -36,14 +35,14 @@ public class AuthController(
     {
         var result = await Mediator.Send(new LoginUserCommand(requestDto));
 
-        if (result.IsFailed)
+        if (!result.IsSuccess)
         {
             return HandleResult(result);
         }
 
-        await signInManager.SignInAsync(result.Value, isPersistent: false);
+        await signInManager.SignInAsync(result.Value!, isPersistent: false);
 
-        var responseDto = mapper.Map<LoginUserResponseDto>(result.Value);
+        var responseDto = mapper.Map<LoginUserResponseDto>(result.Value!);
         return Ok(responseDto);
     }
 

--- a/CVision/Controllers/ApiControllers/BaseApiController.cs
+++ b/CVision/Controllers/ApiControllers/BaseApiController.cs
@@ -1,4 +1,4 @@
-using FluentResults;
+using CVision.BLL.Helpers;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -14,16 +14,6 @@ public class BaseApiController : ControllerBase
     protected IMediator Mediator => _mediator ??=
         HttpContext.RequestServices.GetService<IMediator>()!;
 
-    protected ActionResult HandleResult(Result result)
-    {
-        if (result.IsSuccess)
-        {
-            return Ok();
-        }
-
-        return ProcessErrors(result);
-    }
-
     protected ActionResult HandleResult<T>(Result<T> result)
     {
         if (result.IsSuccess)
@@ -31,28 +21,22 @@ public class BaseApiController : ControllerBase
             return Ok(result.Value);
         }
 
-        return ProcessErrors(result);
-    }
-
-    private ActionResult ProcessErrors(ResultBase result)
-    {
         var problemsFactory = HttpContext.RequestServices
             .GetRequiredService<ProblemDetailsFactory>();
 
-        if (result.HasError(error => error.Message.Contains("not found", StringComparison.CurrentCultureIgnoreCase)))
+        if (result.Error!.Contains("not found", StringComparison.CurrentCultureIgnoreCase))
         {
             return NotFound(problemsFactory.CreateProblemDetails(HttpContext, statusCode: StatusCodes.Status404NotFound));
         }
 
-        if (result.HasError(error => error.Message.Equals("Unauthorized")))
+        if (result.Error!.Equals("Unauthorized"))
         {
             return Unauthorized(problemsFactory.CreateProblemDetails(HttpContext, statusCode: StatusCodes.Status401Unauthorized));
         }
 
-        var errorDetail = string.Join("; ", result.Errors.Select(e => e.Message));
         return BadRequest(problemsFactory.CreateProblemDetails(
             HttpContext,
             statusCode: StatusCodes.Status400BadRequest,
-            detail: errorDetail));
+            detail: result.Error));
     }
 }

--- a/CVision/Controllers/CvAnalysisController.cs
+++ b/CVision/Controllers/CvAnalysisController.cs
@@ -61,7 +61,7 @@ public class CvAnalysisController(IMediator mediator, IMapper mapper) : BaseCont
 
         var result = await mediator.Send(new GetAllByUserIdQuery(userId));
 
-        if (result.IsFailed)
+        if (!result.IsSuccess)
         {
             return View("~/Views/CvAnalysis/CVGallery.cshtml", new CVGalleryPageViewModel
             {

--- a/CVision/Controllers/HomeController.cs
+++ b/CVision/Controllers/HomeController.cs
@@ -28,7 +28,7 @@ public class HomeController(IMediator mediator, ILogger<HomeController> logger) 
         try
         {
             var result = await mediator.Send(new GetUserByIdQuery(userId));
-            if (result.IsFailed || result.ValueOrDefault == null)
+            if (!result.IsSuccess || result.Value == null)
             {
                 TempData["UserWindowError"] = "Не вдалося завантажити дані профілю. Спробуйте ще раз.";
                 return View("user", new UserWindowViewModel());
@@ -63,7 +63,7 @@ public class HomeController(IMediator mediator, ILogger<HomeController> logger) 
         var userId = GetUserId();
 
         var currentUserResult = await mediator.Send(new GetUserByIdQuery(userId));
-        var previousEmail = currentUserResult.ValueOrDefault?.Email;
+        var previousEmail = currentUserResult.Value?.Email;
 
         if (!ModelState.IsValid)
         {
@@ -82,22 +82,22 @@ public class HomeController(IMediator mediator, ILogger<HomeController> logger) 
             };
 
             var updateResult = await mediator.Send(new UpdateProfileCommand(userId, updateRequestDto));
-            if (updateResult.IsFailed)
+            if (!updateResult.IsSuccess)
             {
-                if (!updateResult.Errors.Any())
+                if (updateResult.Error != null)
                 {
-                    ModelState.AddModelError(string.Empty, "Не вдалося оновити профіль. Спробуйте ще раз.");
-                }
-
-                foreach (var error in updateResult.Errors)
-                {
-                    if (string.Equals(error.Message, UserConstants.EmailAlreadyInUse, StringComparison.Ordinal))
+                    if (string.Equals(updateResult.Error, UserConstants.EmailAlreadyInUse, StringComparison.Ordinal))
                     {
                         ModelState.AddModelError(nameof(UserWindowViewModel.Email), "Ця електронна пошта вже зайнята.");
-                        continue;
                     }
-
-                    ModelState.AddModelError(string.Empty, error.Message);
+                    else
+                    {
+                        ModelState.AddModelError(string.Empty, updateResult.Error);
+                    }
+                }
+                else
+                {
+                    ModelState.AddModelError(string.Empty, "Не вдалося оновити профіль. Спробуйте ще раз.");
                 }
 
                 model.MemberSince = await GetMemberSinceAsync(userId);
@@ -164,15 +164,15 @@ public class HomeController(IMediator mediator, ILogger<HomeController> logger) 
             };
 
             var result = await mediator.Send(new UpdatePasswordCommand(userId, requestDto));
-            if (result.IsFailed)
+            if (!result.IsSuccess)
             {
-                if (result.Errors.Any(e => string.Equals(e.Message, UserConstants.IncorrectCurrentPassword, StringComparison.Ordinal)))
+                if (result.Error != null && string.Equals(result.Error, UserConstants.IncorrectCurrentPassword, StringComparison.Ordinal))
                 {
                     TempData["UserPasswordError"] = "Поточний пароль введено невірно.";
                     return RedirectToAction("user");
                 }
 
-                TempData["UserPasswordError"] = result.Errors.FirstOrDefault()?.Message
+                TempData["UserPasswordError"] = result.Error
                     ?? "Не вдалося змінити пароль. Спробуйте ще раз.";
                 return RedirectToAction("user");
             }
@@ -194,6 +194,6 @@ public class HomeController(IMediator mediator, ILogger<HomeController> logger) 
     private async Task<string> GetMemberSinceAsync(int userId)
     {
         var userResult = await mediator.Send(new GetUserByIdQuery(userId));
-        return userResult.ValueOrDefault?.CreatedAt.ToString("dd.MM.yyyy") ?? string.Empty;
+        return userResult.Value?.CreatedAt.ToString("dd.MM.yyyy") ?? string.Empty;
     }
 }

--- a/CVision/Controllers/PublicationController.cs
+++ b/CVision/Controllers/PublicationController.cs
@@ -45,9 +45,9 @@ public class PublicationController(IMediator mediator, IMapper mapper) : BaseCon
 
         var result = await mediator.Send(new DeletePublicationCommand(publicationId, userId));
 
-        if (result.IsFailed)
+        if (!result.IsSuccess)
         {
-            var errorMessage = result.Errors.FirstOrDefault()?.Message ?? "Не вдалося видалити публікацію";
+            var errorMessage = result.Error ?? "Не вдалося видалити публікацію";
 
             var backUrl = Url.Action("GetPublication", "Publication", new { publicationId });
 
@@ -113,9 +113,9 @@ public class PublicationController(IMediator mediator, IMapper mapper) : BaseCon
         var command = new UpdatePublicationCommand(model.Id, userId, requestDto);
         var result = await mediator.Send(command);
 
-        if (result.IsFailed)
+        if (!result.IsSuccess)
         {
-            var errorMessage = result.Errors.FirstOrDefault()?.Message ?? "Невідома помилка при оновленні";
+            var errorMessage = result.Error ?? "Невідома помилка при оновленні";
             var backUrl = Url.Action("GetPublication", "Publication", new { publicationId = model.Id });
 
             return RedirectToAction("ShowError", "Publication", new

--- a/CVisionUnitTests/HandlerTests/CvAnalyses/GetAllByUserIdHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/CvAnalyses/GetAllByUserIdHandlerTests.cs
@@ -56,7 +56,7 @@ public class GetAllByUserIdHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(2, result.Value.Count());
+        Assert.Equal(2, result.Value!.Count());
         _mapperMock.Verify(m => m.Map<IEnumerable<CvAnalysisResponseShortDto>>(entities), Times.Once);
     }
 
@@ -83,6 +83,6 @@ public class GetAllByUserIdHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Empty(result.Value);
+        Assert.Empty(result.Value!);
     }
 }

--- a/CVisionUnitTests/HandlerTests/Publications/DeletePublicationHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Publications/DeletePublicationHandlerTests.cs
@@ -35,8 +35,8 @@ public class DeletePublicationHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(PublicationsConstants.PublicationNotFound, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PublicationsConstants.PublicationNotFound, result.Error);
     }
 
     [Fact]
@@ -60,8 +60,8 @@ public class DeletePublicationHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal("Unauthorized", result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Unauthorized", result.Error);
     }
 
     [Fact]
@@ -87,8 +87,8 @@ public class DeletePublicationHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(PublicationsConstants.PublicationDeleteError, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PublicationsConstants.PublicationDeleteError, result.Error);
     }
 
     [Fact]

--- a/CVisionUnitTests/HandlerTests/Publications/GetAllPublicationsHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Publications/GetAllPublicationsHandlerTests.cs
@@ -54,8 +54,8 @@ public class GetAllPublicationsHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(2, result.Value.Count());
-        Assert.Equal("Test 1", result.Value.First().Title);
+        Assert.Equal(2, result.Value!.Count());
+        Assert.Equal("Test 1", result.Value!.First().Title);
 
         _repositoryWrapperMock.Verify(r => r.PublicationRepository.GetAllAsync(It.IsAny<QueryOptions<Publication>>()), Times.Once);
         _mapperMock.Verify(m => m.Map<IEnumerable<PublicationResponseShortDto>>(publications), Times.Once);
@@ -82,7 +82,7 @@ public class GetAllPublicationsHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Empty(result.Value);
+        Assert.Empty(result.Value!);
         _repositoryWrapperMock.Verify(r => r.PublicationRepository.GetAllAsync(It.IsAny<QueryOptions<Publication>>()), Times.Once);
     }
 

--- a/CVisionUnitTests/HandlerTests/Publications/GetByUserIdHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Publications/GetByUserIdHandlerTests.cs
@@ -56,7 +56,7 @@ public class GetByUserIdHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(2, result.Value.Count());
+        Assert.Equal(2, result.Value!.Count());
         _repositoryWrapperMock.Verify(r => r.PublicationRepository.GetAllAsync(It.IsAny<QueryOptions<Publication>>()), Times.Once);
         _mapperMock.Verify(m => m.Map<IEnumerable<PublicationResponseShortDto>>(publications), Times.Once);
     }
@@ -83,7 +83,7 @@ public class GetByUserIdHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Empty(result.Value);
+        Assert.Empty(result.Value!);
     }
 
     [Fact]

--- a/CVisionUnitTests/HandlerTests/Publications/GetPublicationByIdHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Publications/GetPublicationByIdHandlerTests.cs
@@ -4,7 +4,6 @@ using CVision.BLL.Queries.Publications.GetByPublicationId;
 using CVision.DAL.Entities;
 using CVision.DAL.Repositories.Interfaces.Base;
 using CVision.DAL.Repositories.Options;
-using FluentResults;
 using Moq;
 using Xunit;
 
@@ -56,7 +55,7 @@ public class GetPublicationByIdHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(publicationId, result.Value.Id);
+        Assert.Equal(publicationId, result.Value!.Id);
         _repositoryWrapperMock.Verify(r => r.PublicationRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Publication>>()), Times.Once);
     }
 

--- a/CVisionUnitTests/HandlerTests/Publications/UpdatePublicationHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Publications/UpdatePublicationHandlerTests.cs
@@ -44,8 +44,8 @@ public class UpdatePublicationHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(PublicationsConstants.TitleRequired, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PublicationsConstants.TitleRequired, result.Error);
     }
 
     [Fact]
@@ -62,8 +62,8 @@ public class UpdatePublicationHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(PublicationsConstants.PublicationNotFound, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PublicationsConstants.PublicationNotFound, result.Error);
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public class UpdatePublicationHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal("Unauthorized", result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Unauthorized", result.Error);
     }
 
     [Fact]
@@ -116,8 +116,8 @@ public class UpdatePublicationHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(PublicationsConstants.PublicationUpdateError, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PublicationsConstants.PublicationUpdateError, result.Error);
     }
 
     [Fact]

--- a/CVisionUnitTests/HandlerTests/Users/ConfirmEmailHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Users/ConfirmEmailHandlerTests.cs
@@ -55,8 +55,8 @@ public class ConfirmEmailHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.UserNotFound, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.UserNotFound, result.Error);
 
         _userManagerMock.Verify(u => u.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
     }
@@ -79,8 +79,8 @@ public class ConfirmEmailHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.EmailConfirmationError, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.EmailConfirmationError, result.Error);
     }
 
     [Fact]

--- a/CVisionUnitTests/HandlerTests/Users/GetUserByIdHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Users/GetUserByIdHandlerTests.cs
@@ -59,8 +59,8 @@ public class GetUserByIdHandlerTests
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.UserNotFound, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.UserNotFound, result.Error);
         _mapperMock.Verify(m => m.Map<GetUserResponseDto>(It.IsAny<ApplicationUser>()), Times.Never);
     }
 
@@ -84,7 +84,7 @@ public class GetUserByIdHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(responseDto.Email, result.Value.Email);
+        Assert.Equal(responseDto.Email, result.Value!.Email);
         _userManagerMock.Verify(u => u.FindByIdAsync(userId.ToString()), Times.Once);
     }
 }

--- a/CVisionUnitTests/HandlerTests/Users/LoginUserHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Users/LoginUserHandlerTests.cs
@@ -74,8 +74,8 @@ public class LoginUserHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.EmailRequiredErrorMessage, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.EmailRequiredErrorMessage, result.Error);
 
         _userManagerMock.Verify(u => u.FindByEmailAsync(It.IsAny<string>()), Times.Never);
     }
@@ -97,8 +97,8 @@ public class LoginUserHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.UserLogInError, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.UserLogInError, result.Error);
     }
 
     [Fact]
@@ -122,8 +122,8 @@ public class LoginUserHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.UserLogInError, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.UserLogInError, result.Error);
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class LoginUserHandlerTests
         // Arrange
         var requestDto = new LoginUserRequestDto { Email = "ihor@test.com", Password = "SecurePassword123!" };
         var command = new LoginUserCommand(requestDto);
-        var user = new ApplicationUser { Id = 1, Email = requestDto.Email, UserName = "ihor_prots" };
+        var user = new ApplicationUser { Id = 1, Email = requestDto.Email, UserName = "ihor_prots", EmailConfirmed = true };
 
         _validatorMock.Setup(v => v.ValidateAsync(command, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
@@ -148,7 +148,7 @@ public class LoginUserHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(requestDto.Email, result.Value.Email);
-        Assert.Equal("olya_mraka", result.Value.UserName);
+        Assert.Equal(requestDto.Email, result.Value!.Email);
+        Assert.Equal("ihor_prots", result.Value.UserName);
     }
 }

--- a/CVisionUnitTests/HandlerTests/Users/RegisterUserHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Users/RegisterUserHandlerTests.cs
@@ -82,8 +82,8 @@ public class RegisterUserHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.UserNameRequiredErrorMessage, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.UserNameRequiredErrorMessage, result.Error);
 
         _userManagerMock.Verify(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
     }
@@ -109,8 +109,8 @@ public class RegisterUserHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Contains(identityError, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Contains(identityError, result.Error);
         _emailServiceMock.Verify(e => e.SendConfirmationEmailAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
@@ -146,7 +146,7 @@ public class RegisterUserHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(requestDto.Email, result.Value.Email);
+        Assert.Equal(requestDto.Email, result.Value!.Email);
 
         _emailServiceMock.Verify(
             e => e.SendConfirmationEmailAsync(userEntity.Email, It.IsAny<string>()),

--- a/CVisionUnitTests/HandlerTests/Users/ResetPasswordHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Users/ResetPasswordHandlerTests.cs
@@ -56,8 +56,8 @@ public class ResetPasswordHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.IsFailed.Should().BeTrue();
-        result.Errors.First().Message.Should().Be(UserConstants.PasswordResetError);
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(UserConstants.PasswordResetError);
 
         _userManagerMock.Verify(u => u.ResetPasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
@@ -86,8 +86,8 @@ public class ResetPasswordHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.IsFailed.Should().BeTrue();
-        result.Errors.Select(e => e.Message).Should().Contain("Invalid token.");
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Invalid token.");
     }
 
     [Fact]

--- a/CVisionUnitTests/HandlerTests/Users/UpdatePasswordHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Users/UpdatePasswordHandlerTests.cs
@@ -56,8 +56,8 @@ public class UpdatePasswordHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.IsFailed.Should().BeTrue();
-        result.Errors.First().Message.Should().Be(UserConstants.UserNotFound);
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(UserConstants.UserNotFound);
 
         _userManagerMock.Verify(u => u.ChangePasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
@@ -86,8 +86,8 @@ public class UpdatePasswordHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.IsFailed.Should().BeTrue();
-        result.Errors.First().Message.Should().Be(UserConstants.IncorrectCurrentPassword);
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(UserConstants.IncorrectCurrentPassword);
     }
 
     [Fact]
@@ -110,8 +110,8 @@ public class UpdatePasswordHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.IsFailed.Should().BeTrue();
-        result.Errors.First().Message.Should().Be("Password too short");
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Password too short");
     }
 
     [Fact]

--- a/CVisionUnitTests/HandlerTests/Users/UpdateProfileHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Users/UpdateProfileHandlerTests.cs
@@ -66,8 +66,8 @@ public class UpdateProfileHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.UserNotFound, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.UserNotFound, result.Error);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class UpdateProfileHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal("newname", result.Value.UserName);
+        Assert.Equal("newname", result.Value!.UserName);
         Assert.Equal("123456", result.Value.PhoneNumber);
         _userManagerMock.Verify(u => u.FindByEmailAsync(It.IsAny<string>()), Times.Never);
         _emailServiceMock.Verify(e => e.SendEmailChangeConfirmationAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -184,8 +184,8 @@ public class UpdateProfileHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal(UserConstants.EmailAlreadyInUse, result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserConstants.EmailAlreadyInUse, result.Error);
         _userManagerMock.Verify(u => u.UpdateAsync(It.IsAny<ApplicationUser>()), Times.Never);
     }
 
@@ -214,7 +214,7 @@ public class UpdateProfileHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.True(result.IsFailed);
-        Assert.Equal("Update failed", result.Errors.First().Message);
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Update failed", result.Error);
     }
 }


### PR DESCRIPTION
This pull request refactors the command and handler classes in the `CVision.BLL` layer to remove the dependency on the `FluentResults` library and instead use a custom `Result<T>` type from `CVision.BLL.Helpers`. It also changes the return types and error handling patterns throughout the command handlers, streamlining the error reporting and result structures.

Key changes include:

**Removal of FluentResults and adoption of custom Result type:**

* All command and handler classes now use `CVision.BLL.Helpers.Result<T>` instead of `FluentResults.Result` for return types, with the relevant using statements updated or removed. [[1]](diffhunk://#diff-d2c7a0c4f5e0699c4e289816671834dea33f9e1e1ad18219e519c8c0bda3f8b0L1-R7) [[2]](diffhunk://#diff-309fdacc047fc2358f8ced9bc4e59d5fe719b83cb5068eaaaf6678ad5e8ab141L2-R8) [[3]](diffhunk://#diff-31eabf3c4b9d1212f269a04690773b328c7a579604e731316fe4c8173462e123R2-R8) [[4]](diffhunk://#diff-79ff991330eaceb71b3511bc3ce679dd8fbd4a5315a5820b59c6bbafbc79e1eaL2-R8) [[5]](diffhunk://#diff-6b5e42ff8a5500a33062671b01dada6ae296b79d3d7eedb3c00f0791c7d187f3L3-R3) [[6]](diffhunk://#diff-6b6cc4ad421d95c867a87d5da575b9098ba80d8e4e94bfae2aa6909d571c5052L1-R1) [[7]](diffhunk://#diff-7c1e7bfd6c5d6829041dd70f13fac2d45106537df2271f475763ea53adda755eL2-R8)

**Refactoring of handler logic and return values:**

* Error handling in handlers has been simplified: instead of returning `Result.Fail(...)`, handlers now return error strings or concatenated error messages directly, and on success, they return the result object or `true` for boolean results. [[1]](diffhunk://#diff-03ac8c7efa3fe9c18b705a28fa436efd60533bf5844e83bdee658f1e7caff617L25-R40) [[2]](diffhunk://#diff-fb9264bd642dcfe43b3667ff35ab4f4b6c9de4578e7f452236f538ee44ab9acdL34-R39) [[3]](diffhunk://#diff-ddebe0738e7d8b7203cd8242ef4160d4733836b554c93fe4088c364b1922a9deL18-R33) [[4]](diffhunk://#diff-d9cb6554c10602e7e1ac2d13d852be183f95ee24620cefedf1915446691a5350L26-R32) [[5]](diffhunk://#diff-86c3ca0836419c4033f9c53980b8abefb1c42d160d42e72f43c17b76a53bc27fL23-R45) [[6]](diffhunk://#diff-0c2863622cbfa5399708cf34ba7830a8391aa5e1f74badc5c0c5ef124ca54d85L40-R40) [[7]](diffhunk://#diff-0c2863622cbfa5399708cf34ba7830a8391aa5e1f74badc5c0c5ef124ca54d85L49-R49) [[8]](diffhunk://#diff-793516998b72ea085587d1e8995c2e96b520b469709fe656b99bc347aa5d6bc8L18-R34) [[9]](diffhunk://#diff-32dd0f1d9f3f4d5036fd7d6b178704c4812eea4d23ad46f76363814fb17ea45bL18-R23) [[10]](diffhunk://#diff-32dd0f1d9f3f4d5036fd7d6b178704c4812eea4d23ad46f76363814fb17ea45bL34-R40)

**Standardization of request and handler signatures:**

* All commands and handlers that previously used `Result` or `Result<T>` now use `Result<bool>` or `Result<T>` as appropriate, ensuring consistent typing for MediatR requests and results. [[1]](diffhunk://#diff-d2c7a0c4f5e0699c4e289816671834dea33f9e1e1ad18219e519c8c0bda3f8b0L1-R7) [[2]](diffhunk://#diff-03ac8c7efa3fe9c18b705a28fa436efd60533bf5844e83bdee658f1e7caff617R2-R12) [[3]](diffhunk://#diff-309fdacc047fc2358f8ced9bc4e59d5fe719b83cb5068eaaaf6678ad5e8ab141L2-R8) [[4]](diffhunk://#diff-fb9264bd642dcfe43b3667ff35ab4f4b6c9de4578e7f452236f538ee44ab9acdR2-R22) [[5]](diffhunk://#diff-31eabf3c4b9d1212f269a04690773b328c7a579604e731316fe4c8173462e123R2-R8) [[6]](diffhunk://#diff-ddebe0738e7d8b7203cd8242ef4160d4733836b554c93fe4088c364b1922a9deL1-R9) [[7]](diffhunk://#diff-79ff991330eaceb71b3511bc3ce679dd8fbd4a5315a5820b59c6bbafbc79e1eaL2-R8) [[8]](diffhunk://#diff-d9cb6554c10602e7e1ac2d13d852be183f95ee24620cefedf1915446691a5350R1-R10) [[9]](diffhunk://#diff-6b5e42ff8a5500a33062671b01dada6ae296b79d3d7eedb3c00f0791c7d187f3L3-R3) [[10]](diffhunk://#diff-86c3ca0836419c4033f9c53980b8abefb1c42d160d42e72f43c17b76a53bc27fR2-L3) [[11]](diffhunk://#diff-6b6cc4ad421d95c867a87d5da575b9098ba80d8e4e94bfae2aa6909d571c5052L1-R1) [[12]](diffhunk://#diff-0c2863622cbfa5399708cf34ba7830a8391aa5e1f74badc5c0c5ef124ca54d85L5-R5) [[13]](diffhunk://#diff-c68b5ae81450a202612473e422243b1eded639d0ad01f3735743dbe4297c58cfL2-R8) [[14]](diffhunk://#diff-793516998b72ea085587d1e8995c2e96b520b469709fe656b99bc347aa5d6bc8R2-R9) [[15]](diffhunk://#diff-7c1e7bfd6c5d6829041dd70f13fac2d45106537df2271f475763ea53adda755eL2-R8) [[16]](diffhunk://#diff-32dd0f1d9f3f4d5036fd7d6b178704c4812eea4d23ad46f76363814fb17ea45bR2-R9)

**Cleanup of using directives:**

* Removed unused `FluentResults` using statements and added `CVision.BLL.Helpers` where needed. [[1]](diffhunk://#diff-d2c7a0c4f5e0699c4e289816671834dea33f9e1e1ad18219e519c8c0bda3f8b0L1-R7) [[2]](diffhunk://#diff-03ac8c7efa3fe9c18b705a28fa436efd60533bf5844e83bdee658f1e7caff617R2-R12) [[3]](diffhunk://#diff-309fdacc047fc2358f8ced9bc4e59d5fe719b83cb5068eaaaf6678ad5e8ab141L2-R8) [[4]](diffhunk://#diff-fb9264bd642dcfe43b3667ff35ab4f4b6c9de4578e7f452236f538ee44ab9acdR2-R22) [[5]](diffhunk://#diff-31eabf3c4b9d1212f269a04690773b328c7a579604e731316fe4c8173462e123R2-R8) [[6]](diffhunk://#diff-ddebe0738e7d8b7203cd8242ef4160d4733836b554c93fe4088c364b1922a9deL1-R9) [[7]](diffhunk://#diff-79ff991330eaceb71b3511bc3ce679dd8fbd4a5315a5820b59c6bbafbc79e1eaL2-R8) [[8]](diffhunk://#diff-d9cb6554c10602e7e1ac2d13d852be183f95ee24620cefedf1915446691a5350R1-R10) [[9]](diffhunk://#diff-6b5e42ff8a5500a33062671b01dada6ae296b79d3d7eedb3c00f0791c7d187f3L3-R3) [[10]](diffhunk://#diff-86c3ca0836419c4033f9c53980b8abefb1c42d160d42e72f43c17b76a53bc27fR2-L3) [[11]](diffhunk://#diff-6b6cc4ad421d95c867a87d5da575b9098ba80d8e4e94bfae2aa6909d571c5052L1-R1) [[12]](diffhunk://#diff-0c2863622cbfa5399708cf34ba7830a8391aa5e1f74badc5c0c5ef124ca54d85L5-R5) [[13]](diffhunk://#diff-c68b5ae81450a202612473e422243b1eded639d0ad01f3735743dbe4297c58cfL2-R8) [[14]](diffhunk://#diff-793516998b72ea085587d1e8995c2e96b520b469709fe656b99bc347aa5d6bc8R2-R9) [[15]](diffhunk://#diff-7c1e7bfd6c5d6829041dd70f13fac2d45106537df2271f475763ea53adda755eL2-R8) [[16]](diffhunk://#diff-32dd0f1d9f3f4d5036fd7d6b178704c4812eea4d23ad46f76363814fb17ea45bR2-R9)

**Improved error aggregation and reporting:**

* Where multiple errors could occur (e.g., in registration or password reset), errors are now concatenated into a single string for easier consumption by clients. [[1]](diffhunk://#diff-0c2863622cbfa5399708cf34ba7830a8391aa5e1f74badc5c0c5ef124ca54d85L49-R49) [[2]](diffhunk://#diff-793516998b72ea085587d1e8995c2e96b520b469709fe656b99bc347aa5d6bc8L18-R34) [[3]](diffhunk://#diff-32dd0f1d9f3f4d5036fd7d6b178704c4812eea4d23ad46f76363814fb17ea45bL34-R40)

These changes improve consistency, reduce external dependencies, and simplify error handling across the business logic layer.