### PR TITLE
Implemented delete and view deleted Cv Analyses functionality

### DIFF
--- a/CVision.BLL/Commands/CvAnalyses/Delete/DeleteCvAnalysisCommand.cs
+++ b/CVision.BLL/Commands/CvAnalyses/Delete/DeleteCvAnalysisCommand.cs
@@ -1,0 +1,7 @@
+using CVision.BLL.Helpers;
+using MediatR;
+
+namespace CVision.BLL.Commands.CvAnalyses.Delete;
+
+public record DeleteCvAnalysisCommand(int CvAnalysisId)
+    : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/CvAnalyses/Delete/DeleteCvAnalysisHandler.cs
+++ b/CVision.BLL/Commands/CvAnalyses/Delete/DeleteCvAnalysisHandler.cs
@@ -1,0 +1,50 @@
+using CVision.BLL.Constans;
+using MediatR;
+using CVision.BLL.Helpers;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Options;
+using Microsoft.EntityFrameworkCore;
+
+namespace CVision.BLL.Commands.CvAnalyses.Delete;
+
+public class DeleteCvAnalysisHandler(IRepositoryWrapper repositoryWrapper) : IRequestHandler<DeleteCvAnalysisCommand, Result<bool>>
+{
+    public async Task<Result<bool>> Handle(DeleteCvAnalysisCommand request, CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<CVAnalysis>()
+        {
+            Filter = x => x.Id == request.CvAnalysisId,
+            AsNoTracking = false,
+            Include = x
+                => x.Include(x => x.Recommendations)
+                    .Include(x => x.CV),
+        };
+
+        var result = await repositoryWrapper.CvAnalysisRepository.GetFirstOrDefaultAsync(queryOptions);
+
+        if (result == null)
+        {
+            return false;
+        }
+
+        result.IsDeleted = true;
+        result.DeletedAt = DateTime.UtcNow;
+
+        result.CV.IsDeleted = true;
+        result.CV.DeletedAt = DateTime.UtcNow;
+
+        foreach (var recommendation in result.Recommendations)
+        {
+            recommendation.IsDeleted = true;
+            recommendation.DeletedAt = DateTime.UtcNow;
+        }
+
+        if (await repositoryWrapper.SaveChangesAsync() <= 0)
+        {
+            return CvAnalysisConstants.DbDeleteError;
+        }
+
+        return true;
+    }
+}

--- a/CVision.BLL/Constans/CvAnalysisConstants.cs
+++ b/CVision.BLL/Constans/CvAnalysisConstants.cs
@@ -2,6 +2,8 @@ namespace CVision.BLL.Constans;
 
 public static class CvAnalysisConstants
 {
+    public static readonly int DaysAlive = 30;
+
     public static readonly string CvFileEmptyError
         = "Файл не може бути порожнім!";
 
@@ -22,6 +24,9 @@ public static class CvAnalysisConstants
 
     public static readonly string InvalidUserData
         = "Некоректний користувач!";
+
+    public static readonly string DbDeleteError
+        = "Помилка при видаленні аналізу";
 
     public static string CvSizeError(int size)
     {

--- a/CVision.BLL/DTOs/CvAnalyses/DeletedCvAnalysisResponseDto.cs
+++ b/CVision.BLL/DTOs/CvAnalyses/DeletedCvAnalysisResponseDto.cs
@@ -1,0 +1,10 @@
+namespace CVision.BLL.DTOs.CvAnalyses;
+
+public class DeletedCvAnalysisResponseDto
+{
+    public int Id { get; set; }
+
+    public string FilePath { get; set; } = string.Empty;
+
+    public int Days { get; set; }
+}

--- a/CVision.BLL/Mappers/CvAnalysisProfile.cs
+++ b/CVision.BLL/Mappers/CvAnalysisProfile.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using CVision.BLL.Constans;
 using CVision.DAL.Entities;
 using CVision.BLL.DTOs.CvAnalyses;
 
@@ -15,5 +16,11 @@ public class CvAnalysisProfile : Profile
 
         CreateMap<CVAnalysis, CvAnalysisResponseShortDto>()
             .ForMember(dest => dest.FileUrl, opt => opt.MapFrom(x => x.CV.FilePath));
+
+        CreateMap<CVAnalysis, DeletedCvAnalysisResponseDto>()
+            .ForMember(dest => dest.FilePath, opt => opt.MapFrom(x => x.CV.FilePath))
+            .ForMember(dest => dest.Days,
+                opt => opt.MapFrom(x =>
+                   CvAnalysisConstants.DaysAlive - (DateTime.UtcNow - x.DeletedAt!.Value).TotalDays));
     }
 }

--- a/CVision.BLL/Queries/Comments/GetByPublicationId/GetByPublicationIdHandler.cs
+++ b/CVision.BLL/Queries/Comments/GetByPublicationId/GetByPublicationIdHandler.cs
@@ -19,7 +19,7 @@ public class GetByPublicationIdHandler(
     {
         var queryOptions = new QueryOptions<Comment>
         {
-            Filter = x => x.PublicationId == request.PublicationId,
+            Filter = x => x.PublicationId == request.PublicationId && !x.IsDeleted,
             Include = x =>
                 x.Include(x => x.User)
                     .Include(x => x.ParentComment)

--- a/CVision.BLL/Queries/CvAnalyses/GetAllCvAnalyses/GetAllByUserIdHandler.cs
+++ b/CVision.BLL/Queries/CvAnalyses/GetAllCvAnalyses/GetAllByUserIdHandler.cs
@@ -17,7 +17,7 @@ public class GetAllByUserIdHandler(IMapper mapper, IRepositoryWrapper repository
     {
         var queryOptions = new QueryOptions<CVAnalysis>
         {
-            Filter = cv => cv.CV.UserId == request.UserId,
+            Filter = cv => cv.CV.UserId == request.UserId && !cv.IsDeleted,
             Include = cv => cv.Include(x => x.CV),
         };
 

--- a/CVision.BLL/Queries/CvAnalyses/GetDeletedCvAnalyses/GetDeletedByUserIdHandler.cs
+++ b/CVision.BLL/Queries/CvAnalyses/GetDeletedCvAnalyses/GetDeletedByUserIdHandler.cs
@@ -1,0 +1,36 @@
+using MediatR;
+using AutoMapper;
+using CVision.BLL.Constans;
+using Microsoft.EntityFrameworkCore;
+using CVision.BLL.Helpers;
+using CVision.BLL.DTOs.CvAnalyses;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Options;
+
+namespace CVision.BLL.Queries.CvAnalyses.GetDeletedCvAnalyses;
+
+public class GetDeletedByUserIdHandler(
+    IRepositoryWrapper repositoryWrapper,
+    IMapper mapper) : IRequestHandler<GetDeletedByUserIdQuery, Result<IEnumerable<DeletedCvAnalysisResponseDto>>>
+{
+    public async Task<Result<IEnumerable<DeletedCvAnalysisResponseDto>>> Handle(GetDeletedByUserIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<CVAnalysis>
+        {
+            Filter = x => x.CV.UserId == request.UserId && x.IsDeleted,
+            Include = x => x.Include(x => x.CV),
+        };
+
+        var cvAnalyses = await repositoryWrapper.CvAnalysisRepository.GetAllAsync(queryOptions);
+
+        var filtered = cvAnalyses
+            .Where(x => x.DeletedAt.HasValue && (DateTime.UtcNow - x.DeletedAt.Value).TotalDays < CvAnalysisConstants.DaysAlive)
+            .ToList();
+
+        var response = mapper.Map<IEnumerable<DeletedCvAnalysisResponseDto>>(filtered);
+
+        return Result<IEnumerable<DeletedCvAnalysisResponseDto>>.Ok(response);
+    }
+}

--- a/CVision.BLL/Queries/CvAnalyses/GetDeletedCvAnalyses/GetDeletedByUserIdQuery.cs
+++ b/CVision.BLL/Queries/CvAnalyses/GetDeletedCvAnalyses/GetDeletedByUserIdQuery.cs
@@ -1,0 +1,8 @@
+using CVision.BLL.DTOs.CvAnalyses;
+using CVision.BLL.Helpers;
+using MediatR;
+
+namespace CVision.BLL.Queries.CvAnalyses.GetDeletedCvAnalyses;
+
+public record GetDeletedByUserIdQuery(int UserId)
+    : IRequest<Result<IEnumerable<DeletedCvAnalysisResponseDto>>>;

--- a/CVision.DAL/Entities/CV.cs
+++ b/CVision.DAL/Entities/CV.cs
@@ -14,6 +14,10 @@ public class CV
 
     public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
 
+    public bool IsDeleted { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+
     public virtual ApplicationUser User { get; set; } = null!;
 
     public virtual ICollection<CVAnalysis> Analyses { get; set; } = new List<CVAnalysis>();

--- a/CVision.DAL/Entities/CVAnalysis.cs
+++ b/CVision.DAL/Entities/CVAnalysis.cs
@@ -12,6 +12,10 @@ public class CVAnalysis
 
     public DateTime AnalyzedAt { get; set; } = DateTime.UtcNow;
 
+    public bool IsDeleted { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+
     public virtual CV CV { get; set; } = null!;
 
     public virtual ICollection<CVAnalysisRecommendation> Recommendations { get; set; } = new List<CVAnalysisRecommendation>();

--- a/CVision.DAL/Entities/CVAnalysisRecommendation.cs
+++ b/CVision.DAL/Entities/CVAnalysisRecommendation.cs
@@ -14,5 +14,9 @@ public class CVAnalysisRecommendation
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    public bool IsDeleted { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+
     public virtual CVAnalysis CVAnalysis { get; set; } = null!;
 }

--- a/CVision.DAL/Migrations/20260409081354_AddSoftDeleteToCvAnalysis.Designer.cs
+++ b/CVision.DAL/Migrations/20260409081354_AddSoftDeleteToCvAnalysis.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CVision.DAL.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CVision.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409081354_AddSoftDeleteToCvAnalysis")]
+    partial class AddSoftDeleteToCvAnalysis
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -102,16 +105,10 @@ namespace CVision.DAL.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<string>("FilePath")
                         .IsRequired()
                         .HasMaxLength(255)
                         .HasColumnType("character varying(255)");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
 
                     b.Property<string>("ParsedText")
                         .HasColumnType("text");

--- a/CVision.DAL/Migrations/20260409081354_AddSoftDeleteToCvAnalysis.cs
+++ b/CVision.DAL/Migrations/20260409081354_AddSoftDeleteToCvAnalysis.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CVision.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSoftDeleteToCvAnalysis : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "CVAnalysesRecommendations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "CVAnalysesRecommendations",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "CVAnalyses",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "CVAnalyses",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "CVAnalysesRecommendations");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "CVAnalysesRecommendations");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "CVAnalyses");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "CVAnalyses");
+        }
+    }
+}

--- a/CVision.DAL/Migrations/20260409081920_AddSoftDeleteToCv.Designer.cs
+++ b/CVision.DAL/Migrations/20260409081920_AddSoftDeleteToCv.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CVision.DAL.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CVision.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409081920_AddSoftDeleteToCv")]
+    partial class AddSoftDeleteToCv
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CVision.DAL/Migrations/20260409081920_AddSoftDeleteToCv.cs
+++ b/CVision.DAL/Migrations/20260409081920_AddSoftDeleteToCv.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CVision.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSoftDeleteToCv : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "CVs",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "CVs",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "CVs");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "CVs");
+        }
+    }
+}

--- a/CVision/Controllers/ApiControllers/CvAnalysisController.cs
+++ b/CVision/Controllers/ApiControllers/CvAnalysisController.cs
@@ -1,6 +1,8 @@
 using CVision.BLL.DTOs.CvAnalyses;
 using CVision.BLL.Commands.CvAnalyses.Create;
+using CVision.BLL.Commands.CvAnalyses.Delete;
 using CVision.BLL.Queries.CvAnalyses.GetAllCvAnalyses;
+using CVision.BLL.Queries.CvAnalyses.GetDeletedCvAnalyses;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CVision.Controllers.ApiControllers;
@@ -39,5 +41,23 @@ public class CvAnalysisController : BaseApiController
     public async Task<IActionResult> GetUser([FromRoute] int id)
     {
         return HandleResult(await Mediator.Send(new GetAllByUserIdQuery(id)));
+    }
+
+    [HttpDelete("delete/{id:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteCvAnalysis([FromRoute] int id)
+    {
+        return Ok(await Mediator.Send(new DeleteCvAnalysisCommand(id)));
+    }
+
+    [HttpGet("deleted/{id:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetDeleted([FromRoute] int id)
+    {
+        return Ok(await Mediator.Send(new GetDeletedByUserIdQuery(id)));
     }
 }

--- a/CVision/wwwroot/css/CvForum/confirmation-page.css
+++ b/CVision/wwwroot/css/CvForum/confirmation-page.css
@@ -1,4 +1,3 @@
-/* ── Сторінка підтвердження ── */
 .confirmation-pop-up-block {
     max-width: 1200px;
     margin: 0 auto;
@@ -10,7 +9,6 @@
     min-height: 100vh;
 }
 
-/* ── Блок підтвердження ── */
 .confirm-block {
     background: #fff;
     border: 1px solid #f5ddd4;
@@ -57,7 +55,6 @@
     padding-bottom: 0.5rem;
 }
 
-/* ── Кнопки ── */
 .confirm-block .operations-block {
     display: flex;
     gap: 0.75rem;
@@ -70,7 +67,6 @@
     flex: 1;
 }
 
-/* ── Так, видалити ── */
 .btn-danger-custom {
     width: 100%;
     padding: 0.75rem;
@@ -90,7 +86,6 @@
     border-color: #de7d68;
 }
 
-/* ── Скасувати ── */
 .confirm-block .operations-block > a {
     flex: 1;
     padding: 0.75rem;

--- a/CVision/wwwroot/css/CvForum/cv-forum-create.css
+++ b/CVision/wwwroot/css/CvForum/cv-forum-create.css
@@ -1,4 +1,3 @@
-/* Контейнер сторінки */
 .create-publication-block {
     display: flex;
     flex-direction: column;
@@ -8,7 +7,6 @@
     padding: calc(64px + 2rem) 1rem 3rem;
 }
 
-/* Форма */
 .create-publication-form {
     background: #ffffff;
     border: 1px solid #f5ddd4;
@@ -20,7 +18,6 @@
     box-shadow: 0 4px 24px rgba(230, 150, 120, 0.08);
 }
 
-/* Блоки введення (Title та Description) */
 .title-block,
 .description-block {
     display: flex;
@@ -28,7 +25,6 @@
     gap: 0.6rem;
 }
 
-/* Лейбли (Span над інпутами) */
 .title-block span,
 .description-block span {
     font-size: 11px;
@@ -39,7 +35,6 @@
     padding-left: 4px;
 }
 
-/* Стилізація текстових інпутів */
 .create-publication-form input[type="text"] {
     width: 100%;
     padding: 0.875rem 1.1rem;
@@ -58,12 +53,10 @@
     box-shadow: 0 0 0 4px rgba(232, 144, 124, 0.08);
 }
 
-/* Специфічне налаштування для опису, якщо захочеш змінити на textarea */
 .description-block input {
     min-height: 50px;
 }
 
-/* Кнопка відправки (btn-pink вже є в тебе, але додамо гармонійності) */
 .create-publication-form .btn-pink {
     margin-top: 0.5rem;
     height: 54px;
@@ -76,14 +69,12 @@
     box-shadow: 0 6px 16px rgba(232, 144, 124, 0.35);
 }
 
-/* Футер з кнопкою "Назад" */
 .footer-block {
     display: flex;
     justify-content: center;
     margin-top: 1rem;
 }
 
-/* Адаптивність */
 @media (max-width: 600px) {
     .create-publication-block {
         padding-top: calc(64px + 1rem);

--- a/CVision/wwwroot/css/CvForum/edit-page.css
+++ b/CVision/wwwroot/css/CvForum/edit-page.css
@@ -1,4 +1,3 @@
-/* ── Основний блок ── */
 .edit-block {
     max-width: 640px;
     margin: 0 auto;
@@ -8,7 +7,6 @@
     gap: 1.5rem;
 }
 
-/* ── Форма ── */
 .edit-block form {
     background: #fff;
     border: 1px solid #f5ddd4;
@@ -19,7 +17,6 @@
     gap: 1.25rem;
 }
 
-/* ── Поля форми ── */
 .edit-block .form-group {
     display: flex;
     flex-direction: column;
@@ -63,7 +60,6 @@
     color: #e05555;
 }
 
-/* ── Кнопки ── */
 .edit-block .operations-block {
     display: flex;
     gap: 0.75rem;
@@ -110,7 +106,6 @@
     color: #e8907c;
 }
 
-/* ── Адаптив ── */
 @media (max-width: 600px) {
     .edit-block {
         padding: calc(64px + 1.25rem) 1rem 1.5rem;

--- a/CVision/wwwroot/css/CvForum/error-page.css
+++ b/CVision/wwwroot/css/CvForum/error-page.css
@@ -1,4 +1,3 @@
-/* ── Основний блок ── */
 .error-info-block {
     max-width: 1200px;
     margin: 0 auto;
@@ -10,7 +9,6 @@
     min-height: 100vh;
 }
 
-/* ── Блок помилки ── */
 .info-block {
     background: #fff;
     border: 1px solid #f5ddd4;
@@ -26,7 +24,6 @@
     box-shadow: 0 8px 40px rgba(230, 150, 120, 0.1);
 }
 
-/* ── Іконка ── */
 .info-block::before {
     content: '!';
     display: flex;
@@ -42,7 +39,6 @@
     flex-shrink: 0;
 }
 
-/* ── Заголовок ── */
 .info-block h1 {
     font-size: 18px;
     font-weight: 700;
@@ -51,7 +47,6 @@
     margin: 0;
 }
 
-/* ── Текст помилки ── */
 .info-block p {
     font-size: 13.5px;
     color: #7a6560;
@@ -60,7 +55,6 @@
     padding-bottom: 0.5rem;
 }
 
-/* ── Кнопка ── */
 .info-block a {
     width: 100%;
     padding: 0.8rem;

--- a/CVision/wwwroot/css/CvForum/publication-page.css
+++ b/CVision/wwwroot/css/CvForum/publication-page.css
@@ -1,4 +1,3 @@
-/* ── Основний блок ── */
 .publication-info-block {
     max-width: 1200px;
     margin: 0 auto;
@@ -14,7 +13,6 @@
     gap: 1.5rem;
 }
 
-/* ── Верхній блок: превʼю + контент поруч ── */
 .top-block {
     display: grid;
     grid-template-columns: 360px 1fr;
@@ -22,7 +20,6 @@
     align-items: start;
 }
 
-/* ── Превʼю файлу ── */
 .file-preview-container {
     background: #fff;
     border: 1px solid #f5ddd4;
@@ -41,7 +38,6 @@
     display: block;
 }
 
-/* ── Блок з заголовком і описом ── */
 .main-content-block {
     background: #fff;
     border: 1px solid #f5ddd4;
@@ -77,7 +73,6 @@
     word-break: break-word;
 }
 
-/* ── Кнопки редагування / видалення ── */
 .operations-block {
     display: flex;
     gap: 0.5rem;
@@ -120,7 +115,6 @@
     word-break: break-word;
 }
 
-/* ── Блок коментарів — під усім ── */
 .discussion-block {
     background: #fff;
     border: 1px solid #f5ddd4;
@@ -162,7 +156,6 @@
     margin: 0;
 }
 
-/* ── Адаптив ── */
 @media (max-width: 900px) {
     .top-block {
         grid-template-columns: 1fr;

--- a/CVision/wwwroot/css/exception-handling-page.css
+++ b/CVision/wwwroot/css/exception-handling-page.css
@@ -12,14 +12,13 @@ body {
     font-family: 'DM Sans', sans-serif;
 }
 
-/* 3. Стилі самої картки */
 .exception-block {
     background: #ffffff;
     border: 1px solid #f2dcd3;
     border-radius: 32px;
     padding: 3.5rem 2.5rem;
     max-width: 440px;
-    width: 90%; /* Щоб на мобільних було адекватно */
+    width: 90%;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -28,7 +27,6 @@ body {
     box-sizing: border-box;
 }
 
-/* Коло з номером помилки */
 .status-block {
     width: 110px;
     height: 110px;
@@ -46,7 +44,6 @@ body {
     color: #e8907c;
 }
 
-/* Тексти */
 .additional-message-block::before {
     content: 'Виникла помилка';
     display: block;
@@ -62,7 +59,6 @@ body {
     line-height: 1.6;
 }
 
-/* Кнопка */
 .exception-block a {
     margin-top: 2.5rem;
     display: block;

--- a/CVisionUnitTests/HandlerTests/CvAnalyses/CreateCvAnalysisHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/CvAnalyses/CreateCvAnalysisHandlerTests.cs
@@ -43,6 +43,7 @@ public class CreateCvAnalysisHandlerTests
     [Fact]
     public async Task Handle_ShouldFail_WhenValidationFails()
     {
+        // Arrange
         var command = CreateCommand();
 
         _validatorMock.Setup(v => v.ValidateAsync(command, It.IsAny<CancellationToken>()))
@@ -51,8 +52,10 @@ public class CreateCvAnalysisHandlerTests
                 new ValidationFailure("File", "Validation error"),
             }));
 
+        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
+        // Assert
         Assert.False(result.IsSuccess);
         Assert.Equal("Validation error", result.Error);
     }
@@ -60,13 +63,16 @@ public class CreateCvAnalysisHandlerTests
     [Fact]
     public async Task Handle_ShouldFail_WhenCvSavingFails()
     {
+        // Arrange
         var command = CreateCommand();
         SetupValidFlow();
 
         _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
 
+        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
+        // Assert
         Assert.False(result.IsSuccess);
         Assert.Equal(CvAnalysisConstants.CvSavingError, result.Error);
     }
@@ -74,6 +80,7 @@ public class CreateCvAnalysisHandlerTests
     [Fact]
     public async Task Handle_ShouldFail_WhenCvAnalysisSavingFails()
     {
+        // Arrange
         var command = CreateCommand();
         SetupValidFlow();
 
@@ -81,8 +88,10 @@ public class CreateCvAnalysisHandlerTests
             .ReturnsAsync(1)
             .ReturnsAsync(0);
 
+        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
+        // Assert
         Assert.False(result.IsSuccess);
         Assert.Equal(CvAnalysisConstants.CvAnalysisSavingError, result.Error);
     }
@@ -90,6 +99,7 @@ public class CreateCvAnalysisHandlerTests
     [Fact]
     public async Task Handle_ShouldSucceed_WhenAllIsValid()
     {
+        // Arrange
         var command = CreateCommand();
         SetupValidFlow();
 
@@ -97,15 +107,17 @@ public class CreateCvAnalysisHandlerTests
             .ReturnsAsync(1)
             .ReturnsAsync(1);
 
+        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
+        // Assert
         Assert.True(result.IsSuccess);
-        Assert.IsType<CvAnalysisResultDto>(result.Value);
     }
 
     [Fact]
     public async Task Handle_ShouldCallAllDependencies()
     {
+        // Arrange
         var command = CreateCommand();
         SetupValidFlow();
 
@@ -113,8 +125,10 @@ public class CreateCvAnalysisHandlerTests
             .ReturnsAsync(1)
             .ReturnsAsync(1);
 
+        // Act
         await _handler.Handle(command, CancellationToken.None);
 
+        // Assert
         _fileServiceMock.Verify(f => f.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string>()), Times.Once);
         _cvParserMock.Verify(p => p.ParseAsync(It.IsAny<Stream>(), It.IsAny<string>()), Times.Once);
         _aiServiceMock.Verify(a => a.AnalyzeResumeAsync(It.IsAny<string>()), Times.Once);

--- a/CVisionUnitTests/HandlerTests/CvAnalyses/DeleteCvAnalysisHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/CvAnalyses/DeleteCvAnalysisHandlerTests.cs
@@ -1,0 +1,127 @@
+using CVision.BLL.Commands.CvAnalyses.Delete;
+using CVision.BLL.Constans;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Interfaces.CvAnalyses;
+using CVision.DAL.Repositories.Options;
+using Moq;
+
+namespace CVisionUnitTests.HandlerTests.CvAnalyses;
+
+public class DeleteCvAnalysisHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repoMock = new();
+    private readonly Mock<ICvAnalysisRepository> _cvAnalysisRepoMock = new();
+
+    private readonly DeleteCvAnalysisHandler _handler;
+
+    public DeleteCvAnalysisHandlerTests()
+    {
+        _repoMock.Setup(r => r.CvAnalysisRepository).Returns(_cvAnalysisRepoMock.Object);
+        _handler = new DeleteCvAnalysisHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFalse_WhenAnalysisNotFound()
+    {
+        // Arrange
+        var command = new DeleteCvAnalysisCommand(CvAnalysisId: 1);
+
+        _cvAnalysisRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CVAnalysis>>()))
+            .ReturnsAsync((CVAnalysis?)null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.False(result.Value);
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesAsyncFails()
+    {
+        // Arrange
+        var command = new DeleteCvAnalysisCommand(CvAnalysisId: 1);
+        var existingAnalysis = CreateValidAnalysis(1);
+
+        _cvAnalysisRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CVAnalysis>>()))
+            .ReturnsAsync(existingAnalysis);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CvAnalysisConstants.DbDeleteError, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSucceed_WhenAllIsValid()
+    {
+        // Arrange
+        var command = new DeleteCvAnalysisCommand(CvAnalysisId: 1);
+        var existingAnalysis = CreateValidAnalysis(1);
+
+        _cvAnalysisRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CVAnalysis>>()))
+            .ReturnsAsync(existingAnalysis);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSetSoftDeleteFlagsOnAllRelatedEntities_WhenSuccessful()
+    {
+        // Arrange
+        var command = new DeleteCvAnalysisCommand(CvAnalysisId: 1);
+        var existingAnalysis = CreateValidAnalysis(1);
+
+        _cvAnalysisRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CVAnalysis>>()))
+            .ReturnsAsync(existingAnalysis);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(existingAnalysis.IsDeleted);
+        Assert.NotNull(existingAnalysis.DeletedAt);
+
+        Assert.True(existingAnalysis.CV.IsDeleted);
+        Assert.NotNull(existingAnalysis.CV.DeletedAt);
+
+        Assert.All(existingAnalysis.Recommendations, r =>
+        {
+            Assert.True(r.IsDeleted);
+            Assert.NotNull(r.DeletedAt);
+        });
+
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+
+    private CVAnalysis CreateValidAnalysis(int id)
+    {
+        return new CVAnalysis
+        {
+            Id = id,
+            IsDeleted = false,
+            CV = new CV { Id = 10, IsDeleted = false },
+            Recommendations = new List<CVAnalysisRecommendation>
+            {
+                new CVAnalysisRecommendation { Id = 101, IsDeleted = false },
+                new CVAnalysisRecommendation { Id = 102, IsDeleted = false },
+            },
+        };
+    }
+}

--- a/CVisionUnitTests/HandlerTests/CvAnalyses/GetDeletedByUserIdHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/CvAnalyses/GetDeletedByUserIdHandlerTests.cs
@@ -1,0 +1,114 @@
+using AutoMapper;
+using CVision.BLL.DTOs.CvAnalyses;
+using CVision.BLL.Queries.CvAnalyses.GetDeletedCvAnalyses;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Interfaces.CvAnalyses;
+using CVision.DAL.Repositories.Options;
+using Moq;
+
+namespace CVisionUnitTests.HandlerTests.CvAnalyses;
+
+public class GetDeletedByUserIdHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repoMock = new();
+    private readonly Mock<ICvAnalysisRepository> _cvAnalysisRepoMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly GetDeletedByUserIdHandler _handler;
+
+    public GetDeletedByUserIdHandlerTests()
+    {
+        _repoMock.Setup(r => r.CvAnalysisRepository).Returns(_cvAnalysisRepoMock.Object);
+        _handler = new GetDeletedByUserIdHandler(_repoMock.Object, _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOnlyRecentDeletedAnalyses_WhenCalled()
+    {
+        // Arrange
+        int userId = 1;
+        var query = new GetDeletedByUserIdQuery(userId);
+
+        var recentDeleted = new CVAnalysis
+        {
+            Id = 1,
+            IsDeleted = true,
+            DeletedAt = DateTime.UtcNow.AddDays(-5),
+            CV = new CV { UserId = userId },
+        };
+
+        var oldDeleted = new CVAnalysis
+        {
+            Id = 2,
+            IsDeleted = true,
+            DeletedAt = DateTime.UtcNow.AddDays(-40),
+            CV = new CV { UserId = userId },
+        };
+
+        var allAnalyses = new List<CVAnalysis> { recentDeleted, oldDeleted };
+
+        _cvAnalysisRepoMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<CVAnalysis>>()))
+            .ReturnsAsync(allAnalyses);
+
+        _mapperMock.Setup(m => m.Map<IEnumerable<DeletedCvAnalysisResponseDto>>(It.IsAny<IEnumerable<CVAnalysis>>()))
+            .Returns((IEnumerable<CVAnalysis> source) => source.Select(s => new DeletedCvAnalysisResponseDto { Id = s.Id }));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var responseList = result.Value!.ToList();
+
+        Assert.Single(responseList);
+        Assert.Equal(1, responseList[0].Id);
+
+        _mapperMock.Verify(m => m.Map<IEnumerable<DeletedCvAnalysisResponseDto>>(It.Is<IEnumerable<CVAnalysis>>(list => list.Count() == 1)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenNoAnalysesMatchCriteria()
+    {
+        // Arrange
+        var query = new GetDeletedByUserIdQuery(1);
+
+        _cvAnalysisRepoMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<CVAnalysis>>()))
+            .ReturnsAsync(new List<CVAnalysis>());
+
+        _mapperMock.Setup(m => m.Map<IEnumerable<DeletedCvAnalysisResponseDto>>(It.IsAny<IEnumerable<CVAnalysis>>()))
+            .Returns(new List<DeletedCvAnalysisResponseDto>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value!);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldIgnoreAnalysesWithNullDeletedAt()
+    {
+        // Arrange
+        var query = new GetDeletedByUserIdQuery(1);
+        var analysisWithNullDate = new CVAnalysis
+        {
+            Id = 3,
+            IsDeleted = true,
+            DeletedAt = null,
+            CV = new CV { UserId = 1 },
+        };
+
+        _cvAnalysisRepoMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<CVAnalysis>>()))
+            .ReturnsAsync(new List<CVAnalysis> { analysisWithNullDate });
+
+        _mapperMock.Setup(m => m.Map<IEnumerable<DeletedCvAnalysisResponseDto>>(It.IsAny<IEnumerable<CVAnalysis>>()))
+            .Returns(new List<DeletedCvAnalysisResponseDto>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result.Value!);
+    }
+}

--- a/CVisionUnitTests/HandlerTests/Publications/CreatePublicationHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Publications/CreatePublicationHandlerTests.cs
@@ -63,7 +63,6 @@ public class CreatePublicationHandlerTests
         var command = CreateCommand();
         SetupValidFlow();
 
-        // Імітуємо неуспішне збереження (0 змінених рядків)
         _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
 
         // Act
@@ -81,7 +80,6 @@ public class CreatePublicationHandlerTests
         var command = CreateCommand();
         SetupValidFlow();
 
-        // Sequence: CV зберігається (1), а сама публікація — ні (0)
         _repoMock.SetupSequence(r => r.SaveChangesAsync())
             .ReturnsAsync(1)
             .ReturnsAsync(0);
@@ -129,7 +127,6 @@ public class CreatePublicationHandlerTests
         _cvRepoMock.Verify(r => r.CreateAsync(It.IsAny<CV>()), Times.Once);
         _publicationRepoMock.Verify(r => r.CreateAsync(It.IsAny<Publication>()), Times.Once);
 
-        // Перевіряємо, що SaveChangesAsync викликався двічі (для CV і для Publication)
         _repoMock.Verify(r => r.SaveChangesAsync(), Times.Exactly(2));
     }
 
@@ -160,7 +157,6 @@ public class CreatePublicationHandlerTests
         {
             UserId = 1,
             FileName = "test.pdf",
-            // Створюємо стрім, який можна читати
             FileStream = new MemoryStream(new byte[] { 0x1, 0x2 }),
             ContentType = "application/pdf",
             Title = "Test Title",


### PR DESCRIPTION
This pull request introduces functionality for deleting CV analyses and retrieving previously deleted ones.

The deletion process is implemented as a soft delete. When a CV analysis is deleted, all related entities are also soft-deleted, including associated recommendations and the stored CV file in the database. This ensures data consistency while preserving the ability to restore or review deleted records if needed.

In addition, this PR adds support for viewing deleted CV analyses. Users can access analyses that were deleted within the last 30 days, providing a limited recovery and audit window.

Overall, these changes enhance data management by combining safe deletion practices with controlled access to recently removed records.

**Database Update Required**

_To apply the necessary database changes, run the following command:_

`dotnet ef database update --project CVision.DAL --startup-project CVision`