### PR TITLE
Add comment reactions functionality

### DIFF
--- a/CVision.BLL/Commands/Comments/ToggleReaction/ToggleReactionCommand.cs
+++ b/CVision.BLL/Commands/Comments/ToggleReaction/ToggleReactionCommand.cs
@@ -1,0 +1,9 @@
+using CVision.BLL.DTOs.Comments;
+using CVision.BLL.Helpers;
+using CVision.DAL.Entities;
+using MediatR;
+
+namespace CVision.BLL.Commands.Comments.ToggleReaction;
+
+public record ToggleReactionCommand(int CommentId, int UserId, ReactionType ReactionType)
+    : IRequest<Result<CommentReactionResponseDto>>;

--- a/CVision.BLL/Commands/Comments/ToggleReaction/ToggleReactionHandler.cs
+++ b/CVision.BLL/Commands/Comments/ToggleReaction/ToggleReactionHandler.cs
@@ -1,0 +1,102 @@
+using CVision.BLL.Constans;
+using CVision.BLL.DTOs.Comments;
+using CVision.BLL.Helpers;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Options;
+using MediatR;
+
+namespace CVision.BLL.Commands.Comments.ToggleReaction;
+
+public class ToggleReactionHandler(
+    IRepositoryWrapper repositoryWrapper) : IRequestHandler<ToggleReactionCommand, Result<CommentReactionResponseDto>>
+{
+    public async Task<Result<CommentReactionResponseDto>> Handle(
+        ToggleReactionCommand request,
+        CancellationToken cancellationToken)
+    {
+        var comment = await repositoryWrapper.CommentRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<Comment>
+            {
+                Filter = x => x.Id == request.CommentId && !x.IsDeleted,
+                AsNoTracking = false,
+            });
+
+        if (comment is null)
+        {
+            return CommentsConstants.CommentNotFound;
+        }
+
+        var existingReaction = await repositoryWrapper.CommentReactionRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<CommentReaction>
+            {
+                Filter = x => x.CommentId == request.CommentId && x.UserId == request.UserId,
+                AsNoTracking = false,
+            });
+
+        ReactionType? currentUserReaction;
+
+        if (existingReaction is null)
+        {
+            await repositoryWrapper.CommentReactionRepository.CreateAsync(new CommentReaction
+            {
+                CommentId = request.CommentId,
+                UserId = request.UserId,
+                ReactionType = request.ReactionType,
+            });
+
+            if (request.ReactionType == ReactionType.Like)
+            {
+                comment.Likes++;
+            }
+            else
+            {
+                comment.Dislikes++;
+            }
+
+            currentUserReaction = request.ReactionType;
+        }
+        else if (existingReaction.ReactionType == request.ReactionType)
+        {
+            if (existingReaction.ReactionType == ReactionType.Like)
+            {
+                comment.Likes--;
+            }
+            else
+            {
+                comment.Dislikes--;
+            }
+
+            repositoryWrapper.CommentReactionRepository.Delete(existingReaction);
+            currentUserReaction = null;
+        }
+        else
+        {
+            if (existingReaction.ReactionType == ReactionType.Like)
+            {
+                comment.Likes--;
+                comment.Dislikes++;
+            }
+            else
+            {
+                comment.Dislikes--;
+                comment.Likes++;
+            }
+
+            existingReaction.ReactionType = request.ReactionType;
+            currentUserReaction = request.ReactionType;
+        }
+
+        if (await repositoryWrapper.SaveChangesAsync() <= 0)
+        {
+            return CommentsConstants.ReactionError;
+        }
+
+        return new CommentReactionResponseDto
+        {
+            Likes = comment.Likes,
+            Dislikes = comment.Dislikes,
+            CurrentUserReaction = currentUserReaction,
+        };
+    }
+}

--- a/CVision.BLL/Constans/CommentsConstants.cs
+++ b/CVision.BLL/Constans/CommentsConstants.cs
@@ -23,4 +23,7 @@ public static class CommentsConstants
 
     public static readonly string DeleteCommentError
         = "Помилка видалення коментаря! Спробуйте ще раз!";
+
+    public static readonly string ReactionError
+        = "Помилка при реакції на коментар! Спробуйте ще раз!";
 }

--- a/CVision.BLL/DTOs/Comments/CommentReactionResponseDto.cs
+++ b/CVision.BLL/DTOs/Comments/CommentReactionResponseDto.cs
@@ -1,0 +1,12 @@
+using CVision.DAL.Entities;
+
+namespace CVision.BLL.DTOs.Comments;
+
+public class CommentReactionResponseDto
+{
+    public int Likes { get; set; }
+
+    public int Dislikes { get; set; }
+
+    public ReactionType? CurrentUserReaction { get; set; }
+}

--- a/CVision.BLL/DTOs/Comments/CommentResponseDto.cs
+++ b/CVision.BLL/DTOs/Comments/CommentResponseDto.cs
@@ -1,3 +1,5 @@
+using CVision.DAL.Entities;
+
 namespace CVision.BLL.DTOs.Comments;
 
 public class CommentResponseDto
@@ -11,6 +13,10 @@ public class CommentResponseDto
     public DateTime CreatedAt { get; set; }
 
     public int Likes { get; set; }
+
+    public int Dislikes { get; set; }
+
+    public ReactionType? CurrentUserReaction { get; set; }
 
     public bool IsDeleted { get; set; }
 

--- a/CVision.BLL/Queries/Comments/GetByPublicationId/GetByPublicationIdHandler.cs
+++ b/CVision.BLL/Queries/Comments/GetByPublicationId/GetByPublicationIdHandler.cs
@@ -23,7 +23,8 @@ public class GetByPublicationIdHandler(
             Include = x =>
                 x.Include(x => x.User)
                     .Include(x => x.ParentComment)
-                    .ThenInclude(x => x!.User),
+                    .ThenInclude(x => x!.User)
+                    .Include(x => x.Reactions),
         };
 
         var comments = await repositoryWrapper.CommentRepository.GetAllAsync(queryOptions);
@@ -31,6 +32,18 @@ public class GetByPublicationIdHandler(
         var response = mapper.Map<IEnumerable<CommentResponseDto>>(comments)
             .OrderBy(x => x.CreatedAt)
             .ToList();
+
+        if (request.CurrentUserId.HasValue)
+        {
+            var commentsList = comments.ToList();
+            foreach (var dto in response)
+            {
+                var comment = commentsList.FirstOrDefault(c => c.Id == dto.Id);
+                var userReaction = comment?.Reactions
+                    .FirstOrDefault(r => r.UserId == request.CurrentUserId.Value);
+                dto.CurrentUserReaction = userReaction?.ReactionType;
+            }
+        }
 
         return response;
     }

--- a/CVision.BLL/Queries/Comments/GetByPublicationId/GetByPublicationIdQuery.cs
+++ b/CVision.BLL/Queries/Comments/GetByPublicationId/GetByPublicationIdQuery.cs
@@ -4,5 +4,5 @@ using MediatR;
 
 namespace CVision.BLL.Queries.Comments.GetByPublicationId;
 
-public record GetByPublicationIdQuery(int PublicationId)
+public record GetByPublicationIdQuery(int PublicationId, int? CurrentUserId = null)
     : IRequest<Result<IEnumerable<CommentResponseDto>>>;

--- a/CVision.DAL/Data/ApplicationDbContext.cs
+++ b/CVision.DAL/Data/ApplicationDbContext.cs
@@ -22,6 +22,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
 
     public DbSet<Comment> Comments { get; set; }
 
+    public DbSet<CommentReaction> CommentReactions { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
@@ -126,6 +128,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Content).IsRequired();
             entity.Property(e => e.Likes).HasDefaultValue(0);
+            entity.Property(e => e.Dislikes).HasDefaultValue(0);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
             entity.Property(e => e.IsDeleted).HasDefaultValue(false);
             entity.Property(e => e.DeletedAt).IsRequired(false);
@@ -143,6 +146,25 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
             entity.HasOne(e => e.ParentComment)
                 .WithMany(c => c.Replies)
                 .HasForeignKey(e => e.ParentCommentId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        builder.Entity<CommentReaction>(entity =>
+        {
+            entity.ToTable("CommentReactions");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            entity.HasIndex(e => new { e.CommentId, e.UserId }).IsUnique();
+
+            entity.HasOne(e => e.Comment)
+                .WithMany(c => c.Reactions)
+                .HasForeignKey(e => e.CommentId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(e => e.User)
+                .WithMany(u => u.CommentReactions)
+                .HasForeignKey(e => e.UserId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
     }

--- a/CVision.DAL/Entities/ApplicationUser.cs
+++ b/CVision.DAL/Entities/ApplicationUser.cs
@@ -11,4 +11,6 @@ public class ApplicationUser : IdentityUser<int>
     public virtual ICollection<Publication> Publications { get; set; } = new List<Publication>();
 
     public virtual ICollection<Comment> Comments { get; set; } = new List<Comment>();
+
+    public virtual ICollection<CommentReaction> CommentReactions { get; set; } = new List<CommentReaction>();
 }

--- a/CVision.DAL/Entities/Comment.cs
+++ b/CVision.DAL/Entities/Comment.cs
@@ -14,6 +14,8 @@ public class Comment
 
     public int Likes { get; set; } = 0;
 
+    public int Dislikes { get; set; } = 0;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     public bool IsDeleted { get; set; } = false;
@@ -27,4 +29,6 @@ public class Comment
     public virtual Comment? ParentComment { get; set; }
 
     public virtual ICollection<Comment> Replies { get; set; } = new List<Comment>();
+
+    public virtual ICollection<CommentReaction> Reactions { get; set; } = new List<CommentReaction>();
 }

--- a/CVision.DAL/Entities/CommentReaction.cs
+++ b/CVision.DAL/Entities/CommentReaction.cs
@@ -1,0 +1,18 @@
+namespace CVision.DAL.Entities;
+
+public class CommentReaction
+{
+    public int Id { get; set; }
+
+    public int CommentId { get; set; }
+
+    public int UserId { get; set; }
+
+    public ReactionType ReactionType { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public virtual Comment Comment { get; set; } = null!;
+
+    public virtual ApplicationUser User { get; set; } = null!;
+}

--- a/CVision.DAL/Entities/ReactionType.cs
+++ b/CVision.DAL/Entities/ReactionType.cs
@@ -1,0 +1,7 @@
+namespace CVision.DAL.Entities;
+
+public enum ReactionType
+{
+    Like = 0,
+    Dislike = 1,
+}

--- a/CVision.DAL/Migrations/20260411122445_AddCommentReactions.Designer.cs
+++ b/CVision.DAL/Migrations/20260411122445_AddCommentReactions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CVision.DAL.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CVision.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411122445_AddCommentReactions")]
+    partial class AddCommentReactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -102,16 +105,10 @@ namespace CVision.DAL.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<string>("FilePath")
                         .IsRequired()
                         .HasMaxLength(255)
                         .HasColumnType("character varying(255)");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
 
                     b.Property<string>("ParsedText")
                         .HasColumnType("text");
@@ -151,14 +148,8 @@ namespace CVision.DAL.Migrations
                     b.Property<int>("CVId")
                         .HasColumnType("integer");
 
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<string>("Feedback")
                         .HasColumnType("text");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
 
                     b.Property<int?>("Score")
                         .HasColumnType("integer");
@@ -189,12 +180,6 @@ namespace CVision.DAL.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("CURRENT_TIMESTAMP");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
 
                     b.Property<int?>("SectionScore")
                         .HasColumnType("integer");

--- a/CVision.DAL/Migrations/20260411122445_AddCommentReactions.cs
+++ b/CVision.DAL/Migrations/20260411122445_AddCommentReactions.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CVision.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommentReactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Dislikes",
+                table: "Comments",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "CommentReactions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CommentId = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    ReactionType = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CommentReactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CommentReactions_Comments_CommentId",
+                        column: x => x.CommentId,
+                        principalTable: "Comments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CommentReactions_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommentReactions_CommentId_UserId",
+                table: "CommentReactions",
+                columns: new[] { "CommentId", "UserId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommentReactions_UserId",
+                table: "CommentReactions",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CommentReactions");
+
+            migrationBuilder.DropColumn(
+                name: "Dislikes",
+                table: "Comments");
+        }
+    }
+}

--- a/CVision.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/CVision.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -1,3 +1,4 @@
+using CVision.DAL.Repositories.Interfaces.CommentReactions;
 using CVision.DAL.Repositories.Interfaces.Comments;
 using CVision.DAL.Repositories.Interfaces.CvAnalyses;
 using CVision.DAL.Repositories.Interfaces.CvAnalysisRecommendations;
@@ -17,6 +18,8 @@ public interface IRepositoryWrapper
     public IPublicationRepository PublicationRepository { get; }
 
     public ICommentRepository CommentRepository { get; }
+
+    public ICommentReactionRepository CommentReactionRepository { get; }
 
     int SaveChanges();
 

--- a/CVision.DAL/Repositories/Interfaces/CommentReactions/ICommentReactionRepository.cs
+++ b/CVision.DAL/Repositories/Interfaces/CommentReactions/ICommentReactionRepository.cs
@@ -1,0 +1,8 @@
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+
+namespace CVision.DAL.Repositories.Interfaces.CommentReactions;
+
+public interface ICommentReactionRepository : IRepositoryBase<CommentReaction>
+{
+}

--- a/CVision.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/CVision.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -1,10 +1,12 @@
 using CVision.DAL.Data;
 using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Interfaces.CommentReactions;
 using CVision.DAL.Repositories.Interfaces.Comments;
 using CVision.DAL.Repositories.Interfaces.CvAnalyses;
 using CVision.DAL.Repositories.Interfaces.CvAnalysisRecommendations;
 using CVision.DAL.Repositories.Interfaces.CVs;
 using CVision.DAL.Repositories.Interfaces.Publications;
+using CVision.DAL.Repositories.Realizations.CommentReactions;
 using CVision.DAL.Repositories.Realizations.Comments;
 using CVision.DAL.Repositories.Realizations.CvAnalyses;
 using CVision.DAL.Repositories.Realizations.CvAnalysisRecommendations;
@@ -27,6 +29,8 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     private ICommentRepository? _commentRepository;
 
+    private ICommentReactionRepository? _commentReactionRepository;
+
     public RepositoryWrapper(ApplicationDbContext dbContext)
     {
         context = dbContext;
@@ -46,6 +50,9 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     public ICommentRepository CommentRepository
         => _commentRepository ??= new CommentRepository(context);
+
+    public ICommentReactionRepository CommentReactionRepository
+        => _commentReactionRepository ??= new CommentReactionRepository(context);
 
     public int SaveChanges()
     {

--- a/CVision.DAL/Repositories/Realizations/CommentReactions/CommentReactionRepository.cs
+++ b/CVision.DAL/Repositories/Realizations/CommentReactions/CommentReactionRepository.cs
@@ -1,0 +1,14 @@
+using CVision.DAL.Data;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.CommentReactions;
+using CVision.DAL.Repositories.Realizations.Base;
+
+namespace CVision.DAL.Repositories.Realizations.CommentReactions;
+
+public class CommentReactionRepository : RepositoryBase<CommentReaction>, ICommentReactionRepository
+{
+    public CommentReactionRepository(ApplicationDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/CVision/Controllers/ApiControllers/CommentsController.cs
+++ b/CVision/Controllers/ApiControllers/CommentsController.cs
@@ -1,8 +1,12 @@
+using System.Security.Claims;
 using CVision.BLL.Commands.Comments.Create;
 using CVision.BLL.Commands.Comments.Delete;
+using CVision.BLL.Commands.Comments.ToggleReaction;
 using CVision.BLL.Commands.Comments.Update;
 using CVision.BLL.DTOs.Comments;
 using CVision.BLL.Queries.Comments.GetByPublicationId;
+using CVision.DAL.Entities;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CVision.Controllers.ApiControllers;
@@ -43,5 +47,19 @@ public class CommentsController : BaseApiController
     public async Task<IActionResult> GetCommentsByPublicationId([FromRoute] int publicationId)
     {
         return Ok(await Mediator.Send(new GetByPublicationIdQuery(publicationId)));
+    }
+
+    [Authorize]
+    [HttpPost("{commentId:int}/react/{reactionType}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ToggleReaction(
+        [FromRoute] int commentId,
+        [FromRoute] ReactionType reactionType)
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        return Ok(await Mediator.Send(new ToggleReactionCommand(commentId, userId, reactionType)));
     }
 }

--- a/CVision/Models/ViewModels/CvForum/CommentViewModel.cs
+++ b/CVision/Models/ViewModels/CvForum/CommentViewModel.cs
@@ -19,3 +19,4 @@ public class CommentViewModel
     public bool IsOwn { get; set; }
 }
 
+

--- a/CVisionUnitTests/HandlerTests/Comments/ToggleReactionHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Comments/ToggleReactionHandlerTests.cs
@@ -1,0 +1,254 @@
+using CVision.BLL.Commands.Comments.ToggleReaction;
+using CVision.BLL.Constans;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Interfaces.CommentReactions;
+using CVision.DAL.Repositories.Interfaces.Comments;
+using CVision.DAL.Repositories.Options;
+using Moq;
+
+namespace CVisionUnitTests.HandlerTests.Comments;
+
+public class ToggleReactionHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repoMock = new();
+    private readonly Mock<ICommentRepository> _commentRepoMock = new();
+    private readonly Mock<ICommentReactionRepository> _reactionRepoMock = new();
+
+    private readonly ToggleReactionHandler _handler;
+
+    public ToggleReactionHandlerTests()
+    {
+        _repoMock.Setup(r => r.CommentRepository).Returns(_commentRepoMock.Object);
+        _repoMock.Setup(r => r.CommentReactionRepository).Returns(_reactionRepoMock.Object);
+
+        _handler = new ToggleReactionHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenCommentNotFound()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Like);
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync((Comment?)null);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CommentsConstants.CommentNotFound, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateReaction_WhenNoExistingReaction()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Like);
+
+        var comment = new Comment { Id = 1, Likes = 0, Dislikes = 0 };
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync(comment);
+
+        _reactionRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CommentReaction>>()))
+            .ReturnsAsync((CommentReaction?)null);
+
+        _reactionRepoMock.Setup(r => r.CreateAsync(It.IsAny<CommentReaction>()))
+            .ReturnsAsync((CommentReaction r) => r);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value!.Likes);
+        Assert.Equal(0, result.Value.Dislikes);
+        Assert.Equal(ReactionType.Like, result.Value.CurrentUserReaction);
+        _reactionRepoMock.Verify(r => r.CreateAsync(It.IsAny<CommentReaction>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateDislike_WhenNoExistingReaction()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Dislike);
+
+        var comment = new Comment { Id = 1, Likes = 0, Dislikes = 0 };
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync(comment);
+
+        _reactionRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CommentReaction>>()))
+            .ReturnsAsync((CommentReaction?)null);
+
+        _reactionRepoMock.Setup(r => r.CreateAsync(It.IsAny<CommentReaction>()))
+            .ReturnsAsync((CommentReaction r) => r);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.Value!.Likes);
+        Assert.Equal(1, result.Value.Dislikes);
+        Assert.Equal(ReactionType.Dislike, result.Value.CurrentUserReaction);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldRemoveReaction_WhenSameReactionExists()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Like);
+
+        var comment = new Comment { Id = 1, Likes = 1, Dislikes = 0 };
+        var existingReaction = new CommentReaction
+        {
+            Id = 1,
+            CommentId = 1,
+            UserId = 1,
+            ReactionType = ReactionType.Like,
+        };
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync(comment);
+
+        _reactionRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CommentReaction>>()))
+            .ReturnsAsync(existingReaction);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.Value!.Likes);
+        Assert.Equal(0, result.Value.Dislikes);
+        Assert.Null(result.Value.CurrentUserReaction);
+        _reactionRepoMock.Verify(r => r.Delete(existingReaction), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldRemoveDislike_WhenSameDislikeExists()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Dislike);
+
+        var comment = new Comment { Id = 1, Likes = 0, Dislikes = 1 };
+        var existingReaction = new CommentReaction
+        {
+            Id = 1,
+            CommentId = 1,
+            UserId = 1,
+            ReactionType = ReactionType.Dislike,
+        };
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync(comment);
+
+        _reactionRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CommentReaction>>()))
+            .ReturnsAsync(existingReaction);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.Value!.Likes);
+        Assert.Equal(0, result.Value.Dislikes);
+        Assert.Null(result.Value.CurrentUserReaction);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSwitchFromLikeToDislike()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Dislike);
+
+        var comment = new Comment { Id = 1, Likes = 1, Dislikes = 0 };
+        var existingReaction = new CommentReaction
+        {
+            Id = 1,
+            CommentId = 1,
+            UserId = 1,
+            ReactionType = ReactionType.Like,
+        };
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync(comment);
+
+        _reactionRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CommentReaction>>()))
+            .ReturnsAsync(existingReaction);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.Value!.Likes);
+        Assert.Equal(1, result.Value.Dislikes);
+        Assert.Equal(ReactionType.Dislike, result.Value.CurrentUserReaction);
+        Assert.Equal(ReactionType.Dislike, existingReaction.ReactionType);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSwitchFromDislikeToLike()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Like);
+
+        var comment = new Comment { Id = 1, Likes = 0, Dislikes = 1 };
+        var existingReaction = new CommentReaction
+        {
+            Id = 1,
+            CommentId = 1,
+            UserId = 1,
+            ReactionType = ReactionType.Dislike,
+        };
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync(comment);
+
+        _reactionRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CommentReaction>>()))
+            .ReturnsAsync(existingReaction);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value!.Likes);
+        Assert.Equal(0, result.Value.Dislikes);
+        Assert.Equal(ReactionType.Like, result.Value.CurrentUserReaction);
+        Assert.Equal(ReactionType.Like, existingReaction.ReactionType);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesFails()
+    {
+        var command = new ToggleReactionCommand(CommentId: 1, UserId: 1, ReactionType: ReactionType.Like);
+
+        var comment = new Comment { Id = 1, Likes = 0, Dislikes = 0 };
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync(comment);
+
+        _reactionRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CommentReaction>>()))
+            .ReturnsAsync((CommentReaction?)null);
+
+        _reactionRepoMock.Setup(r => r.CreateAsync(It.IsAny<CommentReaction>()))
+            .ReturnsAsync((CommentReaction r) => r);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CommentsConstants.ReactionError, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotCallSaveChanges_WhenCommentNotFound()
+    {
+        var command = new ToggleReactionCommand(CommentId: 999, UserId: 1, ReactionType: ReactionType.Like);
+
+        _commentRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Comment>>()))
+            .ReturnsAsync((Comment?)null);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Never);
+    }
+}


### PR DESCRIPTION
This pull request introduces the ability for users to react (like/dislike) to comments, tracks these reactions. The changes include new entities, database schema updates, business logic for toggling reactions, and updates to comment DTOs and queries to support and return reaction data.

**Database and Entity Model Changes:**

* Added a new `CommentReaction` entity and corresponding table with relationships to `Comment` and `ApplicationUser`, and enforced a unique constraint per (CommentId, UserId) pair. Also added a `Dislikes` field to the `Comment` entity and table, with migration and model snapshot updates. [[1]](diffhunk://#diff-b695817b992ef6269da7bee2de4dfd9c0662e38462fb5adace0e4428f6d6b8d3R1-R18) [[2]](diffhunk://#diff-dd763d294cd34a43bb4df077d491468e9537fd1bfa034ecdc6f22e77248328a5R1-R7) [[3]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR25-R26) [[4]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR131) [[5]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR151-R169) [[6]](diffhunk://#diff-1c723399d3acab3c6f2e35b8ad72d7337e9043e80500ddc058b556214202655bR17-R18) [[7]](diffhunk://#diff-1c723399d3acab3c6f2e35b8ad72d7337e9043e80500ddc058b556214202655bR32-R33) [[8]](diffhunk://#diff-9b47c4efd14da8519fe7d8e64b2cf7f4b1ef6db02f88e23bbbe71e2aa22d153cR14-R15) [[9]](diffhunk://#diff-70558fc82db543eacbef3e060e132a017800a4666bf95993aa0d4aa095889af3R1-R73) [[10]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR234-R238) [[11]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR269-R300) [[12]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR528-R546) [[13]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR620-R621) [[14]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR641-R642)

**Business Logic and API:**

* Implemented the `ToggleReactionCommand` and `ToggleReactionHandler` to allow users to like/dislike comments, remove their reactions, and switch between like/dislike, updating counts accordingly and returning the result. [[1]](diffhunk://#diff-89a82872e60e16c5542728f17c590b9c3abb0b0a9e1dfe0241d7a75054274b5aR1-R9) [[2]](diffhunk://#diff-2185d2bca19132d95a494cd7acf64edec43476c2a5b096a2511d0bc16851a4f8R1-R102)
* Added error constant for reaction errors in `CommentsConstants`.

**DTO and Query Updates:**

* Extended `CommentResponseDto` with `Dislikes` and `CurrentUserReaction` fields, and created `CommentReactionResponseDto` for reaction responses. [[1]](diffhunk://#diff-502ab674c7889c9359fd355ba09f3e60ff416bfcc69c9ee387499c55662bb62bR1-R12) [[2]](diffhunk://#diff-ad7e0a848c784bd07f6a34dfa538d863d3b603184b76d675147b005c7a0673deR17-R20)
* Updated the `GetByPublicationIdQuery` and its handler to accept a `CurrentUserId` and populate each comment's `CurrentUserReaction` field based on the user's reaction. [[1]](diffhunk://#diff-a8ded10ba1c514e423d6cc193fa42298055507197b5b834f4942f6e68629c84bL7-R7) [[2]](diffhunk://#diff-4690e7b3df15c7c5080ce19b0b212f40cdcf60ee556d320d24d5caf9e722d0e8L26-R27) [[3]](diffhunk://#diff-4690e7b3df15c7c5080ce19b0b212f40cdcf60ee556d320d24d5caf9e722d0e8R36-R47)

**Repository Layer:**

* Registered the new `ICommentReactionRepository` in the repository wrapper interface. [[1]](diffhunk://#diff-d19d863e20cbb5baa640c6f689b0d5370652d469ab2b504267716877986fe44dR1) [[2]](diffhunk://#diff-d19d863e20cbb5baa640c6f689b0d5370652d469ab2b504267716877986fe44dR22-R23)

**Supporting Types:**

* Added the `ReactionType` enum to represent like/dislike.

These changes collectively enable per-user comment reactions and make this data available to clients.