### PR TITLE
Add edit and delete message functionality

### DIFF
--- a/CVision.BLL/Commands/Chat/DeleteMessage/DeleteMessageCommand.cs
+++ b/CVision.BLL/Commands/Chat/DeleteMessage/DeleteMessageCommand.cs
@@ -1,0 +1,6 @@
+using CVision.BLL.Helpers;
+using MediatR;
+
+namespace CVision.BLL.Commands.Chat.DeleteMessage;
+
+public record DeleteMessageCommand(int SenderId, int MessageId) : IRequest<Result<bool>>;

--- a/CVision.BLL/Commands/Chat/DeleteMessage/DeleteMessageHandler.cs
+++ b/CVision.BLL/Commands/Chat/DeleteMessage/DeleteMessageHandler.cs
@@ -1,0 +1,44 @@
+using CVision.BLL.Constans;
+using CVision.BLL.Helpers;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Options;
+using MediatR;
+
+namespace CVision.BLL.Commands.Chat.DeleteMessage;
+
+public class DeleteMessageHandler(
+    IRepositoryWrapper repositoryWrapper) : IRequestHandler<DeleteMessageCommand, Result<bool>>
+{
+    public async Task<Result<bool>> Handle(
+        DeleteMessageCommand request,
+        CancellationToken cancellationToken)
+    {
+        var message = await repositoryWrapper.ChatMessageRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<ChatMessage>
+            {
+                Filter = x => x.Id == request.MessageId && !x.IsDeleted,
+                AsNoTracking = false,
+            });
+
+        if (message is null)
+        {
+            return ChatConstants.MessageNotFound;
+        }
+
+        if (message.SenderId != request.SenderId)
+        {
+            return ChatConstants.NotMessageOwner;
+        }
+
+        message.IsDeleted = true;
+        message.DeletedAt = DateTime.UtcNow;
+
+        if (await repositoryWrapper.SaveChangesAsync() <= 0)
+        {
+            return ChatConstants.DeleteMessageError;
+        }
+
+        return true;
+    }
+}

--- a/CVision.BLL/Commands/Chat/EditMessage/EditMessageCommand.cs
+++ b/CVision.BLL/Commands/Chat/EditMessage/EditMessageCommand.cs
@@ -1,0 +1,8 @@
+using CVision.BLL.DTOs.Chat;
+using CVision.BLL.Helpers;
+using MediatR;
+
+namespace CVision.BLL.Commands.Chat.EditMessage;
+
+public record EditMessageCommand(int SenderId, EditMessageRequestDto RequestDto)
+    : IRequest<Result<ChatMessageDto>>;

--- a/CVision.BLL/Commands/Chat/EditMessage/EditMessageHandler.cs
+++ b/CVision.BLL/Commands/Chat/EditMessage/EditMessageHandler.cs
@@ -1,0 +1,66 @@
+using AutoMapper;
+using CVision.BLL.Constans;
+using CVision.BLL.DTOs.Chat;
+using CVision.BLL.Helpers;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Options;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace CVision.BLL.Commands.Chat.EditMessage;
+
+public class EditMessageHandler(
+    IRepositoryWrapper repositoryWrapper,
+    IMapper mapper,
+    IValidator<EditMessageCommand> validator) : IRequestHandler<EditMessageCommand, Result<ChatMessageDto>>
+{
+    public async Task<Result<ChatMessageDto>> Handle(
+        EditMessageCommand request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return validationResult.Errors.First().ErrorMessage;
+        }
+
+        var message = await repositoryWrapper.ChatMessageRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<ChatMessage>
+            {
+                Filter = x => x.Id == request.RequestDto.Id && !x.IsDeleted,
+                AsNoTracking = false,
+            });
+
+        if (message is null)
+        {
+            return ChatConstants.MessageNotFound;
+        }
+
+        if (message.SenderId != request.SenderId)
+        {
+            return ChatConstants.NotMessageOwner;
+        }
+
+        message.Content = request.RequestDto.Content;
+        message.IsEdited = true;
+        message.EditedAt = DateTime.UtcNow;
+
+        repositoryWrapper.ChatMessageRepository.Update(message);
+
+        if (await repositoryWrapper.SaveChangesAsync() <= 0)
+        {
+            return ChatConstants.UpdateMessageError;
+        }
+
+        var saved = await repositoryWrapper.ChatMessageRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<ChatMessage>
+            {
+                Filter = x => x.Id == message.Id,
+                Include = x => x.Include(m => m.Sender).Include(m => m.Receiver),
+            });
+
+        return mapper.Map<ChatMessageDto>(saved);
+    }
+}

--- a/CVision.BLL/Commands/Chat/MarkAsRead/MarkConversationAsReadHandler.cs
+++ b/CVision.BLL/Commands/Chat/MarkAsRead/MarkConversationAsReadHandler.cs
@@ -16,7 +16,8 @@ public class MarkConversationAsReadHandler(
         var unread = await repositoryWrapper.ChatMessageRepository.GetAllAsync(
             new QueryOptions<ChatMessage>
             {
-                Filter = x => x.ReceiverId == request.CurrentUserId
+                Filter = x => !x.IsDeleted
+                              && x.ReceiverId == request.CurrentUserId
                               && x.SenderId == request.OtherUserId
                               && !x.IsRead,
                 AsNoTracking = false,

--- a/CVision.BLL/Constans/ChatConstants.cs
+++ b/CVision.BLL/Constans/ChatConstants.cs
@@ -20,4 +20,16 @@ public static class ChatConstants
 
     public static readonly string SaveMessageError
         = "Помилка надсилання повідомлення! Спробуйте ще раз!";
+
+    public static readonly string MessageNotFound
+        = "Повідомлення не знайдено!";
+
+    public static readonly string NotMessageOwner
+        = "Ви не можете редагувати або видаляти чуже повідомлення!";
+
+    public static readonly string UpdateMessageError
+        = "Помилка оновлення повідомлення! Спробуйте ще раз!";
+
+    public static readonly string DeleteMessageError
+        = "Помилка видалення повідомлення! Спробуйте ще раз!";
 }

--- a/CVision.BLL/DTOs/Chat/ChatMessageDto.cs
+++ b/CVision.BLL/DTOs/Chat/ChatMessageDto.cs
@@ -19,4 +19,8 @@ public class ChatMessageDto
     public bool IsRead { get; set; }
 
     public DateTime? ReadAt { get; set; }
+
+    public bool IsEdited { get; set; }
+
+    public DateTime? EditedAt { get; set; }
 }

--- a/CVision.BLL/DTOs/Chat/EditMessageRequestDto.cs
+++ b/CVision.BLL/DTOs/Chat/EditMessageRequestDto.cs
@@ -1,0 +1,8 @@
+namespace CVision.BLL.DTOs.Chat;
+
+public class EditMessageRequestDto
+{
+    public int Id { get; set; }
+
+    public string Content { get; set; } = string.Empty;
+}

--- a/CVision.BLL/Queries/Chat/GetConversation/GetConversationHandler.cs
+++ b/CVision.BLL/Queries/Chat/GetConversation/GetConversationHandler.cs
@@ -20,8 +20,9 @@ public class GetConversationHandler(
         var messages = await repositoryWrapper.ChatMessageRepository.GetAllAsync(
             new QueryOptions<ChatMessage>
             {
-                Filter = x => (x.SenderId == request.CurrentUserId && x.ReceiverId == request.OtherUserId)
-                              || (x.SenderId == request.OtherUserId && x.ReceiverId == request.CurrentUserId),
+                Filter = x => !x.IsDeleted
+                              && ((x.SenderId == request.CurrentUserId && x.ReceiverId == request.OtherUserId)
+                                  || (x.SenderId == request.OtherUserId && x.ReceiverId == request.CurrentUserId)),
                 Include = x => x.Include(m => m.Sender).Include(m => m.Receiver),
                 Offset = request.Skip ?? 0,
                 Limit = request.Take ?? 0,

--- a/CVision.BLL/Queries/Chat/GetConversations/GetConversationsHandler.cs
+++ b/CVision.BLL/Queries/Chat/GetConversations/GetConversationsHandler.cs
@@ -18,7 +18,8 @@ public class GetConversationsHandler(
         var messages = await repositoryWrapper.ChatMessageRepository.GetAllAsync(
             new QueryOptions<ChatMessage>
             {
-                Filter = x => x.SenderId == request.CurrentUserId || x.ReceiverId == request.CurrentUserId,
+                Filter = x => !x.IsDeleted
+                              && (x.SenderId == request.CurrentUserId || x.ReceiverId == request.CurrentUserId),
                 Include = x => x.Include(m => m.Sender).Include(m => m.Receiver),
             });
 

--- a/CVision.BLL/Validators/Chat/EditMessageValidator.cs
+++ b/CVision.BLL/Validators/Chat/EditMessageValidator.cs
@@ -1,0 +1,15 @@
+using CVision.BLL.Commands.Chat.EditMessage;
+using CVision.BLL.Constans;
+using FluentValidation;
+
+namespace CVision.BLL.Validators.Chat;
+
+public class EditMessageValidator : AbstractValidator<EditMessageCommand>
+{
+    public EditMessageValidator()
+    {
+        RuleFor(x => x.RequestDto.Content)
+            .NotEmpty().WithMessage(ChatConstants.MessageContentRequired)
+            .MaximumLength(ChatConstants.MaxMessageLength).WithMessage(ChatConstants.MessageMaxLengthError);
+    }
+}

--- a/CVision.DAL/Data/ApplicationDbContext.cs
+++ b/CVision.DAL/Data/ApplicationDbContext.cs
@@ -216,6 +216,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
             entity.Property(e => e.Content).IsRequired();
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
             entity.Property(e => e.IsRead).HasDefaultValue(false);
+            entity.Property(e => e.IsDeleted).HasDefaultValue(false);
+            entity.Property(e => e.IsEdited).HasDefaultValue(false);
 
             entity.HasIndex(e => new { e.SenderId, e.ReceiverId, e.CreatedAt });
 

--- a/CVision.DAL/Entities/ChatMessage.cs
+++ b/CVision.DAL/Entities/ChatMessage.cs
@@ -16,6 +16,14 @@ public class ChatMessage
 
     public DateTime? ReadAt { get; set; }
 
+    public bool IsDeleted { get; set; } = false;
+
+    public DateTime? DeletedAt { get; set; }
+
+    public bool IsEdited { get; set; } = false;
+
+    public DateTime? EditedAt { get; set; }
+
     public virtual ApplicationUser Sender { get; set; } = null!;
 
     public virtual ApplicationUser Receiver { get; set; } = null!;

--- a/CVision.DAL/Migrations/20260426084831_AddChatMessageEditDelete.Designer.cs
+++ b/CVision.DAL/Migrations/20260426084831_AddChatMessageEditDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CVision.DAL.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CVision.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426084831_AddChatMessageEditDelete")]
+    partial class AddChatMessageEditDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CVision.DAL/Migrations/20260426084831_AddChatMessageEditDelete.cs
+++ b/CVision.DAL/Migrations/20260426084831_AddChatMessageEditDelete.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CVision.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChatMessageEditDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "ChatMessages",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "EditedAt",
+                table: "ChatMessages",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "ChatMessages",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsEdited",
+                table: "ChatMessages",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "ChatMessages");
+
+            migrationBuilder.DropColumn(
+                name: "EditedAt",
+                table: "ChatMessages");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "ChatMessages");
+
+            migrationBuilder.DropColumn(
+                name: "IsEdited",
+                table: "ChatMessages");
+        }
+    }
+}

--- a/CVision/Controllers/ApiControllers/ChatController.cs
+++ b/CVision/Controllers/ApiControllers/ChatController.cs
@@ -1,4 +1,6 @@
 using System.Security.Claims;
+using CVision.BLL.Commands.Chat.DeleteMessage;
+using CVision.BLL.Commands.Chat.EditMessage;
 using CVision.BLL.Commands.Chat.MarkAsRead;
 using CVision.BLL.Commands.Chat.SendMessage;
 using CVision.BLL.DTOs.Chat;
@@ -51,5 +53,26 @@ public class ChatController : BaseApiController
     {
         var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
         return HandleResult(await Mediator.Send(new MarkConversationAsReadCommand(userId, otherUserId)));
+    }
+
+    [HttpPut("edit")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ChatMessageDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> EditMessage([FromBody] EditMessageRequestDto requestDto)
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        return HandleResult(await Mediator.Send(new EditMessageCommand(userId, requestDto)));
+    }
+
+    [HttpDelete("delete/{messageId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteMessage([FromRoute] int messageId)
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        return HandleResult(await Mediator.Send(new DeleteMessageCommand(userId, messageId)));
     }
 }

--- a/CVisionUnitTests/HandlerTests/Chat/DeleteMessageHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Chat/DeleteMessageHandlerTests.cs
@@ -1,0 +1,145 @@
+using CVision.BLL.Commands.Chat.DeleteMessage;
+using CVision.BLL.Constans;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Interfaces.ChatMessages;
+using CVision.DAL.Repositories.Options;
+using Moq;
+
+namespace CVisionUnitTests.HandlerTests.Chat;
+
+public class DeleteMessageHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repoMock = new();
+    private readonly Mock<IChatMessageRepository> _chatRepoMock = new();
+
+    private readonly DeleteMessageHandler _handler;
+
+    public DeleteMessageHandlerTests()
+    {
+        _repoMock.Setup(r => r.ChatMessageRepository).Returns(_chatRepoMock.Object);
+
+        _handler = new DeleteMessageHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenMessageNotFound()
+    {
+        var command = new DeleteMessageCommand(SenderId: 1, MessageId: 1);
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync((ChatMessage?)null);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ChatConstants.MessageNotFound, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenNotMessageOwner()
+    {
+        var command = new DeleteMessageCommand(SenderId: 1, MessageId: 1);
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(new ChatMessage { Id = 1, SenderId = 2, Content = "Test" });
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ChatConstants.NotMessageOwner, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesFails()
+    {
+        var command = new DeleteMessageCommand(SenderId: 1, MessageId: 1);
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(new ChatMessage { Id = 1, SenderId = 1, Content = "Test" });
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ChatConstants.DeleteMessageError, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSucceed_WhenAllIsValid()
+    {
+        var command = new DeleteMessageCommand(SenderId: 1, MessageId: 1);
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(new ChatMessage { Id = 1, SenderId = 1, Content = "Test" });
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSetIsDeletedAndDeletedAt_WhenSuccessful()
+    {
+        var command = new DeleteMessageCommand(SenderId: 1, MessageId: 1);
+
+        var existingMessage = new ChatMessage
+        {
+            Id = 1,
+            SenderId = 1,
+            Content = "Test",
+            IsDeleted = false,
+            DeletedAt = null,
+        };
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(existingMessage);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(existingMessage.IsDeleted);
+        Assert.NotNull(existingMessage.DeletedAt);
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotModifyMessage_WhenMessageNotFound()
+    {
+        var command = new DeleteMessageCommand(SenderId: 1, MessageId: 999);
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync((ChatMessage?)null);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotModifyMessage_WhenNotOwner()
+    {
+        var command = new DeleteMessageCommand(SenderId: 1, MessageId: 1);
+
+        var existingMessage = new ChatMessage
+        {
+            Id = 1,
+            SenderId = 2,
+            Content = "Test",
+            IsDeleted = false,
+        };
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(existingMessage);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(existingMessage.IsDeleted);
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Never);
+    }
+}

--- a/CVisionUnitTests/HandlerTests/Chat/EditMessageHandlerTests.cs
+++ b/CVisionUnitTests/HandlerTests/Chat/EditMessageHandlerTests.cs
@@ -1,0 +1,209 @@
+using AutoMapper;
+using CVision.BLL.Commands.Chat.EditMessage;
+using CVision.BLL.Constans;
+using CVision.BLL.DTOs.Chat;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+using CVision.DAL.Repositories.Interfaces.ChatMessages;
+using CVision.DAL.Repositories.Options;
+using FluentValidation;
+using FluentValidation.Results;
+using Moq;
+
+namespace CVisionUnitTests.HandlerTests.Chat;
+
+public class EditMessageHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repoMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<IChatMessageRepository> _chatRepoMock = new();
+    private readonly Mock<IValidator<EditMessageCommand>> _validatorMock = new();
+
+    private readonly EditMessageHandler _handler;
+
+    public EditMessageHandlerTests()
+    {
+        _repoMock.Setup(r => r.ChatMessageRepository).Returns(_chatRepoMock.Object);
+
+        _handler = new EditMessageHandler(
+            _repoMock.Object,
+            _mapperMock.Object,
+            _validatorMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        var command = CreateCommand();
+
+        _validatorMock.Setup(v => v.ValidateAsync(command, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new[]
+            {
+                new ValidationFailure("Content", ChatConstants.MessageContentRequired),
+            }));
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ChatConstants.MessageContentRequired, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenMessageNotFound()
+    {
+        var command = CreateCommand();
+        SetupValidValidation();
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync((ChatMessage?)null);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ChatConstants.MessageNotFound, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenNotMessageOwner()
+    {
+        var command = CreateCommand(senderId: 1);
+        SetupValidValidation();
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(new ChatMessage { Id = 1, SenderId = 2, Content = "Original" });
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ChatConstants.NotMessageOwner, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesFails()
+    {
+        var command = CreateCommand(senderId: 1);
+        SetupValidFlow(senderId: 1);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ChatConstants.UpdateMessageError, result.Error);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSucceed_WhenAllIsValid()
+    {
+        var command = CreateCommand(senderId: 1, content: "Updated content");
+        SetupValidFlow(senderId: 1);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal("Updated content", result.Value!.Content);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSetIsEditedAndEditedAt()
+    {
+        var command = CreateCommand(senderId: 1, content: "New text");
+        SetupValidValidation();
+
+        var existingMessage = new ChatMessage
+        {
+            Id = 1,
+            SenderId = 1,
+            Content = "Old text",
+            IsEdited = false,
+            EditedAt = null,
+        };
+
+        _chatRepoMock.SetupSequence(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(existingMessage)
+            .ReturnsAsync(existingMessage);
+
+        _mapperMock.Setup(m => m.Map<ChatMessageDto>(It.IsAny<ChatMessage>()))
+            .Returns(new ChatMessageDto { Id = 1, Content = "New text", IsEdited = true });
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal("New text", existingMessage.Content);
+        Assert.True(existingMessage.IsEdited);
+        Assert.NotNull(existingMessage.EditedAt);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallUpdateAndSaveChanges()
+    {
+        var command = CreateCommand(senderId: 1);
+        SetupValidFlow(senderId: 1);
+
+        _repoMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _chatRepoMock.Verify(r => r.Update(It.IsAny<ChatMessage>()), Times.Once);
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotCallUpdate_WhenMessageNotFound()
+    {
+        var command = CreateCommand();
+        SetupValidValidation();
+
+        _chatRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync((ChatMessage?)null);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _chatRepoMock.Verify(r => r.Update(It.IsAny<ChatMessage>()), Times.Never);
+        _repoMock.Verify(r => r.SaveChangesAsync(), Times.Never);
+    }
+
+    private static EditMessageCommand CreateCommand(int senderId = 1, string content = "Updated content")
+    {
+        return new EditMessageCommand(senderId, new EditMessageRequestDto
+        {
+            Id = 1,
+            Content = content,
+        });
+    }
+
+    private void SetupValidValidation()
+    {
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<EditMessageCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+    }
+
+    private void SetupValidFlow(int senderId = 1)
+    {
+        SetupValidValidation();
+
+        var existingMessage = new ChatMessage
+        {
+            Id = 1,
+            SenderId = senderId,
+            Content = "Old content",
+        };
+
+        _chatRepoMock.SetupSequence(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChatMessage>>()))
+            .ReturnsAsync(existingMessage)
+            .ReturnsAsync(existingMessage);
+
+        _mapperMock.Setup(m => m.Map<ChatMessageDto>(It.IsAny<ChatMessage>()))
+            .Returns(new ChatMessageDto
+            {
+                Id = 1,
+                SenderId = senderId,
+                Content = "Updated content",
+                IsEdited = true,
+            });
+    }
+}

--- a/CVisionUnitTests/ValidatorsTests/EditMessageValidatorTests.cs
+++ b/CVisionUnitTests/ValidatorsTests/EditMessageValidatorTests.cs
@@ -1,0 +1,80 @@
+using CVision.BLL.Commands.Chat.EditMessage;
+using CVision.BLL.Constans;
+using CVision.BLL.DTOs.Chat;
+using CVision.BLL.Validators.Chat;
+using FluentValidation.TestHelper;
+
+namespace CVisionUnitTests.ValidatorsTests;
+
+public class EditMessageValidatorTests
+{
+    private readonly EditMessageValidator _validator;
+
+    public EditMessageValidatorTests()
+    {
+        _validator = new EditMessageValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Content_Is_Empty()
+    {
+        var command = CreateCommand(content: string.Empty);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.RequestDto.Content)
+            .WithErrorMessage(ChatConstants.MessageContentRequired);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Content_Is_Too_Long()
+    {
+        var longContent = new string('a', ChatConstants.MaxMessageLength + 1);
+        var command = CreateCommand(content: longContent);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.RequestDto.Content)
+            .WithErrorMessage(ChatConstants.MessageMaxLengthError);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Content_Is_Valid()
+    {
+        var command = CreateCommand(content: "Valid message content");
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.RequestDto.Content);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Any_Errors_When_Model_Is_Valid()
+    {
+        var command = CreateCommand();
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Content_Is_At_Max_Length()
+    {
+        var maxContent = new string('a', ChatConstants.MaxMessageLength);
+        var command = CreateCommand(content: maxContent);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.RequestDto.Content);
+    }
+
+    private static EditMessageCommand CreateCommand(string content = "Valid edited message")
+    {
+        return new EditMessageCommand(1, new EditMessageRequestDto
+        {
+            Id = 1,
+            Content = content,
+        });
+    }
+}


### PR DESCRIPTION
This pull request introduces the ability to edit and delete chat messages, improves message visibility logic, and updates the database schema and API to support these features. It also adds validation, error handling, and unit tests to ensure robust behavior.

**Chat message edit/delete functionality:**

* Added support for editing messages, including new command, handler, validator, DTOs, and API endpoint. Messages track `IsEdited` and `EditedAt` fields. [[1]](diffhunk://#diff-0dd722193d27dc564cd94c26aced040352047a09d9c3fde59e533d781d5c393cR1-R8) [[2]](diffhunk://#diff-6deb49ff7364e71dee41e4f1eceb5cb56fc144e17c94cdf1a373813b072bf512R1-R66) [[3]](diffhunk://#diff-e41415336fed19759f07006f8c8c322d9aeb620f47e64f8a20e5ae49aa5f2864R1-R8) [[4]](diffhunk://#diff-59e691ebfdd22da71b2ab86da6d3a472d9b746b1b9b159d46766558da0e9af23R1-R15) [[5]](diffhunk://#diff-5b9faad76205b53b23b7a6ee424a09d4a913c32a5f0d0211998855d3591f0642R22-R25) [[6]](diffhunk://#diff-d773f7af9f4236219750654b0888de143bb37d6a696906de17884ffeeb42f4a1R57-R77) [[7]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR219-R220) [[8]](diffhunk://#diff-b943321123f7fa71bef4509b98dada835cfa8ae1a9784f08059128cc144b11d3R19-R26) [[9]](diffhunk://#diff-e3828d254003c027eb1fd04b99d71fd8eb737bdb11a8a39f926a3a98575e3f94R1-R61) [[10]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR231-R246)
* Added support for deleting messages (soft delete), including command, handler, API endpoint, and corresponding fields `IsDeleted` and `DeletedAt`. [[1]](diffhunk://#diff-50480ffab84fbfd1824873c98bea5f9ef1562affacad4746196ac75870e55755R1-R6) [[2]](diffhunk://#diff-ac5c0d93427e45164327b77835726915a7fcec050570daae9fa549d9d1d840aeR1-R44) [[3]](diffhunk://#diff-d773f7af9f4236219750654b0888de143bb37d6a696906de17884ffeeb42f4a1R57-R77) [[4]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR219-R220) [[5]](diffhunk://#diff-b943321123f7fa71bef4509b98dada835cfa8ae1a9784f08059128cc144b11d3R19-R26) [[6]](diffhunk://#diff-e3828d254003c027eb1fd04b99d71fd8eb737bdb11a8a39f926a3a98575e3f94R1-R61) [[7]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR231-R246)

**Message visibility and filtering:**

* Updated all relevant queries (conversation retrieval, mark as read, get conversations) to filter out deleted messages by checking `IsDeleted`. [[1]](diffhunk://#diff-699658e0d613cbe9c735f78c941b57dcd1c4b2caa5f3d24f09807b29d8c2201bL19-R20) [[2]](diffhunk://#diff-2fd77a99108befb23f4f91bf41865219c845ede58d8d5f11f3ea29b247311b51L23-R25) [[3]](diffhunk://#diff-791d70e83c0c60df451be2dddd80752e30060e362147acb595234b1bfd0c5a78L21-R22)

**Validation and error handling:**

* Introduced new error messages in `ChatConstants` for not found, unauthorized, and failed operations on messages.
* Added a validator for editing messages to enforce content requirements and length.

**Database schema changes:**

* Updated the `ChatMessage` entity and database migration to include `IsDeleted`, `DeletedAt`, `IsEdited`, and `EditedAt` fields with appropriate defaults. [[1]](diffhunk://#diff-b943321123f7fa71bef4509b98dada835cfa8ae1a9784f08059128cc144b11d3R19-R26) [[2]](diffhunk://#diff-e3828d254003c027eb1fd04b99d71fd8eb737bdb11a8a39f926a3a98575e3f94R1-R61) [[3]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR231-R246) [[4]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR219-R220)

**Testing:**

* Added comprehensive unit tests for the delete message handler, covering success and failure scenarios.