### PR TITLE
Implement rate limiting

### DIFF
--- a/CVision/Controllers/AccountController.cs
+++ b/CVision/Controllers/AccountController.cs
@@ -4,6 +4,7 @@ using CVision.BLL.Commands.Users.ForgotPassword;
 using CVision.BLL.Commands.Users.Register;
 using CVision.BLL.Commands.Users.ResetPassword;
 using CVision.BLL.DTOs.Users;
+using CVision.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using CVision.Models.ViewModels.AuthViewModels;
 using MediatR;
@@ -69,6 +70,7 @@ namespace CVision.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [RateLimit(maxRequests: 5, timeWindowInSeconds: 60)]
         public async Task<IActionResult> Login(LogInViewModel model, string? returnUrl = null)
         {
             LoginUserRequestDto requestDto = new LoginUserRequestDto()
@@ -210,6 +212,7 @@ namespace CVision.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [RateLimit(maxRequests: 3, timeWindowInSeconds: 60)]
         public async Task<IActionResult> Register(RegisterViewModel model)
         {
             if (!ModelState.IsValid)

--- a/CVision/Controllers/AnalyticsController.cs
+++ b/CVision/Controllers/AnalyticsController.cs
@@ -3,7 +3,7 @@ using CVision.Models.ViewModels.SalaryViewModels;
 using MediatR;
 using AutoMapper;
 using CVision.Helpers.Constants;
-using CVision.BLL.DTOs.Analytics;
+using CVision.Extensions;
 using CVision.BLL.Queries.Analytics;
 
 
@@ -19,6 +19,7 @@ public class AnalyticsController(IMediator mediator, IMapper mapper) : BaseContr
 
     [HttpPost]
     [ValidateAntiForgeryToken]
+    [RateLimit(maxRequests: 5, timeWindowInSeconds: 60)]
     public async Task<IActionResult> SalaryAnalytics(SalaryDataViewModel model)
     {
         if (string.IsNullOrWhiteSpace(model.JobTitle) || string.IsNullOrWhiteSpace(model.City))

--- a/CVision/Controllers/CvAnalysisController.cs
+++ b/CVision/Controllers/CvAnalysisController.cs
@@ -2,6 +2,7 @@ using MediatR;
 using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using CVision.Extensions;
 using CVision.Helpers.Constants;
 using CVision.Models.ViewModels.CVAnalysisViewModels;
 using CVision.BLL.Commands.CvAnalyses.Create;
@@ -25,6 +26,7 @@ public class CvAnalysisController(IMediator mediator, IMapper mapper) : BaseCont
     [HttpPost]
     [Authorize]
     [ValidateAntiForgeryToken]
+    [RateLimit(maxRequests: 5, timeWindowInSeconds: 60)]
     public async Task<IActionResult> Analyze(IFormFile file)
     {
         var userId = GetUserId();

--- a/CVision/Controllers/ErrorsController.cs
+++ b/CVision/Controllers/ErrorsController.cs
@@ -18,6 +18,7 @@ public class ErrorsController : Controller
             403 => ErorrWindowConstants.Error403,
             404 => ErorrWindowConstants.Error404,
             408 => ErorrWindowConstants.Error408,
+            429 => ErorrWindowConstants.Error429,
             500 => ErorrWindowConstants.Error500,
             _ => ErorrWindowConstants.UnknownError,
         };

--- a/CVision/Extensions/RateLimitAttribute.cs
+++ b/CVision/Extensions/RateLimitAttribute.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CVision.Extensions;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+public class RateLimitAttribute : ActionFilterAttribute
+{
+    private readonly int _maxRequests;
+    private readonly int _timeWindowInSeconds;
+
+    public RateLimitAttribute(int maxRequests = 10, int timeWindowInSeconds = 60)
+    {
+        _maxRequests = maxRequests;
+        _timeWindowInSeconds = timeWindowInSeconds;
+    }
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        var memoryCache = context.HttpContext.RequestServices.GetRequiredService<IMemoryCache>();
+        var ipAddress = GetClientIpAddress(context.HttpContext);
+        var actionPath = context.ActionDescriptor.DisplayName ?? "unknown";
+
+        var cacheKey = $"RateLimit_{ipAddress}_{actionPath}";
+
+        var cacheEntry = memoryCache.GetOrCreate(cacheKey, entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(_timeWindowInSeconds);
+            return new RateLimitEntry { Count = 0, FirstRequestTime = DateTime.UtcNow };
+        });
+
+        if (cacheEntry == null)
+        {
+            cacheEntry = new RateLimitEntry { Count = 0, FirstRequestTime = DateTime.UtcNow };
+        }
+
+        if (DateTime.UtcNow - cacheEntry.FirstRequestTime > TimeSpan.FromSeconds(_timeWindowInSeconds))
+        {
+            cacheEntry.Count = 1;
+            cacheEntry.FirstRequestTime = DateTime.UtcNow;
+        }
+        else
+        {
+            cacheEntry.Count++;
+        }
+
+        memoryCache.Set(cacheKey, cacheEntry, TimeSpan.FromSeconds(_timeWindowInSeconds));
+
+        if (cacheEntry.Count > _maxRequests)
+        {
+            var logger = context.HttpContext.RequestServices.GetService<ILogger<RateLimitAttribute>>();
+            logger?.LogWarning(
+                "Rate limit exceeded for IP {IpAddress} on action {Action}. Requests: {Count}/{Max}",
+                ipAddress,
+                actionPath,
+                cacheEntry.Count,
+                _maxRequests);
+
+            context.Result = new RedirectToActionResult("Error", "Errors", new { statusCode = 429 });
+            return;
+        }
+
+        base.OnActionExecuting(context);
+    }
+
+    private static string GetClientIpAddress(HttpContext context)
+    {
+        var forwardedFor = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(forwardedFor))
+        {
+            return forwardedFor.Split(',')[0].Trim();
+        }
+
+        var realIp = context.Request.Headers["X-Real-IP"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(realIp))
+        {
+            return realIp;
+        }
+
+        return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+
+    private class RateLimitEntry
+    {
+        public int Count { get; set; }
+
+        public DateTime FirstRequestTime { get; set; }
+    }
+}

--- a/CVision/Helpers/Constants/ErorrWindowConstants.cs
+++ b/CVision/Helpers/Constants/ErorrWindowConstants.cs
@@ -21,6 +21,9 @@ public static class ErorrWindowConstants
     public static readonly string Error408
         = "Сервер занадто довго чекав на відповідь. Перевірте з'єднання.";
 
+    public static readonly string Error429
+        = "Занадто багато запитів. Зачекайте хвилину і спробуйте ще раз.";
+
     public static readonly string Error500
         = "На сервері щось зламалося. Наші розробники вже отримали сповіщення.";
 


### PR DESCRIPTION
This pull request introduces a custom rate limiting mechanism to protect key controller actions from excessive requests, helping prevent abuse and improve application stability. The main changes include the implementation of a reusable `RateLimitAttribute`, its application to authentication and CV analysis endpoints, and improved error handling for rate-limited requests.

**Rate limiting implementation:**

* Added a new `RateLimitAttribute` in `CVision/Extensions/RateLimitAttribute.cs` that restricts the number of allowed requests per IP per action within a configurable time window. If the limit is exceeded, users are redirected to an error page.

**Applying rate limits to endpoints:**

* Applied `[RateLimit(maxRequests: 5, timeWindowInSeconds: 60)]` to the `Login` and `Analyze` actions, and `[RateLimit(maxRequests: 3, timeWindowInSeconds: 60)]` to the `Register` action in their respective controllers to limit brute-force and abusive requests. [[1]](diffhunk://#diff-1c2b81e1fbda6e462a9c6018213eb3ce09f360205455d44af26ee84e3b1740d2R73) [[2]](diffhunk://#diff-1c2b81e1fbda6e462a9c6018213eb3ce09f360205455d44af26ee84e3b1740d2R215) [[3]](diffhunk://#diff-b612244643696530d0278704c088828964a6b2f44f709ab25a46c31323144a96R29)

**Error handling and messaging:**

* Added support for HTTP 429 (Too Many Requests) errors in the `ErrorsController` and corresponding error message in `ErorrWindowConstants`. This ensures users receive a clear message when rate limits are exceeded. [[1]](diffhunk://#diff-73da99a86049093214ecf41f9bc5be7d4276e91385cb9f097a974c751d5d4d8cR21) [[2]](diffhunk://#diff-b644289a3e472919c885a994a1ff1ba9379d8a47b7fc782844a9745fa060a3f2R24-R26)

**Dependency updates:**

* Updated controller files to include the new `CVision.Extensions` namespace for access to the rate limiting attribute. [[1]](diffhunk://#diff-1c2b81e1fbda6e462a9c6018213eb3ce09f360205455d44af26ee84e3b1740d2R7) [[2]](diffhunk://#diff-b612244643696530d0278704c088828964a6b2f44f709ab25a46c31323144a96R5)