### PR TITLE
Add notifications and SignalR

### DIFF
--- a/CVision.DAL/Data/ApplicationDbContext.cs
+++ b/CVision.DAL/Data/ApplicationDbContext.cs
@@ -30,6 +30,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
 
     public DbSet<ChatMessage> ChatMessages { get; set; }
 
+    public DbSet<Notification> Notifications { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
@@ -230,6 +232,21 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
                 .WithMany(u => u.ReceivedMessages)
                 .HasForeignKey(e => e.ReceiverId)
                 .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        builder.Entity<Notification>(entity =>
+        {
+            entity.ToTable("Notifications");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Title).IsRequired().HasMaxLength(255);
+            entity.Property(e => e.Message).IsRequired().HasMaxLength(500);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(e => e.IsRead).HasDefaultValue(false);
+
+            entity.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
     }
 }

--- a/CVision.DAL/Entities/Notification.cs
+++ b/CVision.DAL/Entities/Notification.cs
@@ -1,0 +1,24 @@
+namespace CVision.DAL.Entities;
+
+public class Notification
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Message { get; set; } = string.Empty;
+
+    public NotificationType Type { get; set; }
+
+    public bool IsRead { get; set; } = false;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? ReadAt { get; set; }
+
+    public int? RelatedEntityId { get; set; }
+
+    public virtual ApplicationUser User { get; set; } = null!;
+}

--- a/CVision.DAL/Entities/NotificationType.cs
+++ b/CVision.DAL/Entities/NotificationType.cs
@@ -1,0 +1,8 @@
+namespace CVision.DAL.Entities;
+
+public enum NotificationType
+{
+    NewMessage = 0,
+    NewComment = 1,
+    NewContact = 2,
+}

--- a/CVision.DAL/Migrations/20260503163214_AddNotifications.Designer.cs
+++ b/CVision.DAL/Migrations/20260503163214_AddNotifications.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CVision.DAL.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CVision.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503163214_AddNotifications")]
+    partial class AddNotifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CVision.DAL/Migrations/20260503163214_AddNotifications.cs
+++ b/CVision.DAL/Migrations/20260503163214_AddNotifications.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CVision.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Notifications",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    Title = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Message = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    IsRead = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    ReadAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RelatedEntityId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Notifications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Notifications_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_UserId",
+                table: "Notifications",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Notifications");
+        }
+    }
+}

--- a/CVision.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/CVision.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -6,6 +6,7 @@ using CVision.DAL.Repositories.Interfaces.CvAnalyses;
 using CVision.DAL.Repositories.Interfaces.CvAnalysisRecommendations;
 using CVision.DAL.Repositories.Interfaces.CvLookups;
 using CVision.DAL.Repositories.Interfaces.CVs;
+using CVision.DAL.Repositories.Interfaces.Notifications;
 using CVision.DAL.Repositories.Interfaces.Publications;
 
 namespace CVision.DAL.Repositories.Interfaces.Base;
@@ -29,6 +30,8 @@ public interface IRepositoryWrapper
     public IContactRepository ContactRepository { get; }
 
     public IChatMessageRepository ChatMessageRepository { get; }
+
+    public INotificationRepository NotificationRepository { get; }
 
     int SaveChanges();
 

--- a/CVision.DAL/Repositories/Interfaces/Notifications/INotificationRepository.cs
+++ b/CVision.DAL/Repositories/Interfaces/Notifications/INotificationRepository.cs
@@ -1,0 +1,8 @@
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Base;
+
+namespace CVision.DAL.Repositories.Interfaces.Notifications;
+
+public interface INotificationRepository : IRepositoryBase<Notification>
+{
+}

--- a/CVision.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/CVision.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -8,6 +8,7 @@ using CVision.DAL.Repositories.Interfaces.CvAnalyses;
 using CVision.DAL.Repositories.Interfaces.CvAnalysisRecommendations;
 using CVision.DAL.Repositories.Interfaces.CvLookups;
 using CVision.DAL.Repositories.Interfaces.CVs;
+using CVision.DAL.Repositories.Interfaces.Notifications;
 using CVision.DAL.Repositories.Interfaces.Publications;
 using CVision.DAL.Repositories.Realizations.ChatMessages;
 using CVision.DAL.Repositories.Realizations.CommentReactions;
@@ -17,6 +18,7 @@ using CVision.DAL.Repositories.Realizations.CvAnalyses;
 using CVision.DAL.Repositories.Realizations.CvAnalysisRecommendations;
 using CVision.DAL.Repositories.Realizations.CvLookups;
 using CVision.DAL.Repositories.Realizations.CVs;
+using CVision.DAL.Repositories.Realizations.Notifications;
 using CVision.DAL.Repositories.Realizations.Publications;
 
 namespace CVision.DAL.Repositories.Realizations.Base;
@@ -42,6 +44,8 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IContactRepository? _contactRepository;
 
     private IChatMessageRepository? _chatMessageRepository;
+
+    private INotificationRepository? _notificationRepository;
 
     public RepositoryWrapper(ApplicationDbContext dbContext)
     {
@@ -74,6 +78,9 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     public IChatMessageRepository ChatMessageRepository
         => _chatMessageRepository ??= new ChatMessageRepository(context);
+
+    public INotificationRepository NotificationRepository
+        => _notificationRepository ??= new NotificationRepository(context);
 
     public int SaveChanges()
     {

--- a/CVision.DAL/Repositories/Realizations/Notifications/NotificationRepository.cs
+++ b/CVision.DAL/Repositories/Realizations/Notifications/NotificationRepository.cs
@@ -1,0 +1,14 @@
+using CVision.DAL.Data;
+using CVision.DAL.Entities;
+using CVision.DAL.Repositories.Interfaces.Notifications;
+using CVision.DAL.Repositories.Realizations.Base;
+
+namespace CVision.DAL.Repositories.Realizations.Notifications;
+
+public class NotificationRepository : RepositoryBase<Notification>, INotificationRepository
+{
+    public NotificationRepository(ApplicationDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/CVision/CVision.csproj
+++ b/CVision/CVision.csproj
@@ -18,6 +18,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="9.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     </ItemGroup>

--- a/CVision/Controllers/ApiControllers/NotificationsController.cs
+++ b/CVision/Controllers/ApiControllers/NotificationsController.cs
@@ -1,0 +1,89 @@
+using System.Security.Claims;
+using CVision.DAL.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace CVision.Controllers.ApiControllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+public class NotificationsController : ControllerBase
+{
+    private readonly ApplicationDbContext _db;
+
+    public NotificationsController(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+
+        var notifications = await _db.Notifications
+            .Where(n => n.UserId == userId)
+            .OrderByDescending(n => n.CreatedAt)
+            .Take(50)
+            .Select(n => new
+            {
+                n.Id,
+                n.Title,
+                n.Message,
+                Type = n.Type.ToString(),
+                n.IsRead,
+                n.CreatedAt,
+                n.RelatedEntityId,
+            })
+            .ToListAsync();
+
+        return Ok(notifications);
+    }
+
+    [HttpGet("unread-count")]
+    public async Task<IActionResult> GetUnreadCount()
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+
+        var count = await _db.Notifications
+            .CountAsync(n => n.UserId == userId && !n.IsRead);
+
+        return Ok(new { count });
+    }
+
+    [HttpPost("{id}/mark-read")]
+    public async Task<IActionResult> MarkAsRead(int id)
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+
+        var notification = await _db.Notifications
+            .FirstOrDefaultAsync(n => n.Id == id && n.UserId == userId);
+
+        if (notification == null)
+        {
+            return NotFound();
+        }
+
+        notification.IsRead = true;
+        notification.ReadAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        return Ok();
+    }
+
+    [HttpPost("mark-all-read")]
+    public async Task<IActionResult> MarkAllAsRead()
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+
+        await _db.Notifications
+            .Where(n => n.UserId == userId && !n.IsRead)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(n => n.IsRead, true)
+                .SetProperty(n => n.ReadAt, DateTime.UtcNow));
+
+        return Ok();
+    }
+}

--- a/CVision/Hubs/NotificationHub.cs
+++ b/CVision/Hubs/NotificationHub.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace CVision.Hubs;
+
+[Authorize]
+public class NotificationHub : Hub
+{
+    public override async Task OnConnectedAsync()
+    {
+        var userId = Context.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        if (!string.IsNullOrEmpty(userId))
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, $"user_{userId}");
+        }
+
+        await base.OnConnectedAsync();
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        var userId = Context.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        if (!string.IsNullOrEmpty(userId))
+        {
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"user_{userId}");
+        }
+
+        await base.OnDisconnectedAsync(exception);
+    }
+}

--- a/CVision/Program.cs
+++ b/CVision/Program.cs
@@ -8,9 +8,11 @@ using CVision.BLL.Mappers;
 using CVision.BLL.Options;
 using CVision.BLL.Services;
 using CVision.BLL.Validators.Users;
+using CVision.Hubs;
 using CVision.Mappers;
 using CVision.Extensions;
 using CVision.Extensions.Middleware;
+using CVision.Services;
 using FluentValidation;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -57,6 +59,8 @@ string geminiApiKey = builder.Configuration["GeminiApiKey"]
 builder.Services.AddScoped<IAIService>(sp => new GeminiService(geminiApiKey));
 
 builder.Services.AddControllersWithViews();
+builder.Services.AddSignalR();
+builder.Services.AddHostedService<NotificationBackgroundService>();
 builder.Services.AddSession();
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
@@ -117,5 +121,6 @@ app.MapControllerRoute(
         pattern: "{controller=Home}/{action=Index}/{id?}")
     .WithStaticAssets();
 
+app.MapHub<NotificationHub>("/hubs/notifications");
 
 app.Run();

--- a/CVision/Services/NotificationBackgroundService.cs
+++ b/CVision/Services/NotificationBackgroundService.cs
@@ -1,0 +1,214 @@
+using CVision.DAL.Data;
+using CVision.DAL.Entities;
+using CVision.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+namespace CVision.Services;
+
+public class NotificationBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IHubContext<NotificationHub> _hubContext;
+    private readonly ILogger<NotificationBackgroundService> _logger;
+
+    private DateTime _lastChecked = DateTime.UtcNow;
+
+    public NotificationBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IHubContext<NotificationHub> hubContext,
+        ILogger<NotificationBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("NotificationBackgroundService started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await CheckForNewEvents(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in NotificationBackgroundService loop.");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+
+        _logger.LogInformation("NotificationBackgroundService stopped.");
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Length <= maxLength ? value : value[..maxLength] + "...";
+    }
+
+    private async Task CheckForNewEvents(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var checkTime = DateTime.UtcNow;
+
+        await CheckNewMessages(dbContext, ct);
+        await CheckNewComments(dbContext, ct);
+        await CheckNewContacts(dbContext, ct);
+
+        _lastChecked = checkTime;
+    }
+
+    private async Task CheckNewMessages(ApplicationDbContext db, CancellationToken ct)
+    {
+        var newMessages = await db.ChatMessages
+            .Include(m => m.Sender)
+            .Where(m => m.CreatedAt > _lastChecked && !m.IsDeleted)
+            .ToListAsync(ct);
+
+        foreach (var message in newMessages)
+        {
+            var exists = await db.Notifications
+                .AnyAsync(
+                    n => n.RelatedEntityId == message.Id && n.Type == NotificationType.NewMessage,
+                    ct);
+
+            if (exists)
+            {
+                continue;
+            }
+
+            var notification = new Notification
+            {
+                UserId = message.ReceiverId,
+                Title = "Нове повідомлення",
+                Message = $"{message.Sender.UserName} надіслав вам повідомлення",
+                Type = NotificationType.NewMessage,
+                RelatedEntityId = message.Id,
+                CreatedAt = DateTime.UtcNow,
+            };
+
+            db.Notifications.Add(notification);
+            await db.SaveChangesAsync(ct);
+
+            await SendNotificationToUser(
+                notification.UserId,
+                notification,
+                ct);
+        }
+    }
+
+    private async Task CheckNewComments(ApplicationDbContext db, CancellationToken ct)
+    {
+        var newComments = await db.Comments
+            .Include(c => c.User)
+            .Include(c => c.Publication)
+            .Where(c => c.CreatedAt > _lastChecked && !c.IsDeleted)
+            .ToListAsync(ct);
+
+        foreach (var comment in newComments)
+        {
+            if (comment.Publication.UserId == comment.UserId)
+            {
+                continue;
+            }
+
+            var exists = await db.Notifications
+                .AnyAsync(
+                    n => n.RelatedEntityId == comment.Id && n.Type == NotificationType.NewComment,
+                    ct);
+
+            if (exists)
+            {
+                continue;
+            }
+
+            var notification = new Notification
+            {
+                UserId = comment.Publication.UserId,
+                Title = "Новий коментар",
+                Message = $"{comment.User.UserName} прокоментував вашу публікацію \"{Truncate(comment.Publication.Title, 30)}\"",
+                Type = NotificationType.NewComment,
+                RelatedEntityId = comment.Id,
+                CreatedAt = DateTime.UtcNow,
+            };
+
+            db.Notifications.Add(notification);
+            await db.SaveChangesAsync(ct);
+
+            await SendNotificationToUser(
+                notification.UserId,
+                notification,
+                ct);
+        }
+    }
+
+    private async Task CheckNewContacts(ApplicationDbContext db, CancellationToken ct)
+    {
+        var newContacts = await db.Contacts
+            .Include(c => c.Owner)
+            .Where(c => c.CreatedAt > _lastChecked)
+            .ToListAsync(ct);
+
+        foreach (var contact in newContacts)
+        {
+            var exists = await db.Notifications
+                .AnyAsync(
+                    n => n.RelatedEntityId == contact.Id && n.Type == NotificationType.NewContact,
+                    ct);
+
+            if (exists)
+            {
+                continue;
+            }
+
+            var notification = new Notification
+            {
+                UserId = contact.ContactUserId,
+                Title = "Новий контакт",
+                Message = $"{contact.Owner.UserName} додав вас до своїх контактів",
+                Type = NotificationType.NewContact,
+                RelatedEntityId = contact.Id,
+                CreatedAt = DateTime.UtcNow,
+            };
+
+            db.Notifications.Add(notification);
+            await db.SaveChangesAsync(ct);
+
+            await SendNotificationToUser(
+                notification.UserId,
+                notification,
+                ct);
+        }
+    }
+
+    private async Task SendNotificationToUser(
+        int userId,
+        Notification notification,
+        CancellationToken ct)
+    {
+        await _hubContext.Clients.Group($"user_{userId}")
+            .SendAsync(
+                "ReceiveNotification",
+                new
+                {
+                    notification.Id,
+                    notification.Title,
+                    notification.Message,
+                    Type = notification.Type.ToString(),
+                    notification.CreatedAt,
+                    notification.RelatedEntityId,
+                },
+                ct);
+    }
+}


### PR DESCRIPTION
This pull request introduces a complete notifications feature to the application, including database support, repository and entity definitions, API endpoints for notification management, and real-time push notifications using SignalR. The changes span the data layer, API controllers, and application configuration to enable users to receive, query, and mark notifications as read.

**Notifications feature implementation:**

* Added the `Notification` entity and `NotificationType` enum, with properties for user association, content, status, and timestamps. (`CVision.DAL/Entities/Notification.cs`, `CVision.DAL/Entities/NotificationType.cs`) [[1]](diffhunk://#diff-ed46937abb09a6b52b7962a8cf60f2c4c456b235f7155e27e7046edbf5cd10abR1-R24) [[2]](diffhunk://#diff-c284b9669a95cf30f1c96d5bb1bd8447c82d6a2fb1d6f4b9e37fc853bb000b28R1-R8)
* Created a new database table for notifications, including migration and model snapshot updates for schema and relationships. (`CVision.DAL/Data/ApplicationDbContext.cs`, `CVision.DAL/Migrations/20260503163214_AddNotifications.cs`, `CVision.DAL/Migrations/ApplicationDbContextModelSnapshot.cs`) [[1]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR33-R34) [[2]](diffhunk://#diff-6a22672f7603647d74e4e10f32f9a68063d31fede224895b9c578037402285eeR236-R250) [[3]](diffhunk://#diff-faba37dd04467e98a0b8a91a3a1eb1471a7d217b763c7d7baadc751fd1aacdc4R1-R54) [[4]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR409-R455) [[5]](diffhunk://#diff-d1626349329cdc0805d879e80bbec0e62b438625cce29008704d2bb550c1e4abR751-R761)

**Repository and data access:**

* Introduced `INotificationRepository` and its implementation, and registered them in the repository wrapper for dependency injection. (`CVision.DAL/Repositories/Interfaces/Notifications/INotificationRepository.cs`, `CVision.DAL/Repositories/Realizations/Notifications/NotificationRepository.cs`, `CVision.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs`, `CVision.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs`) [[1]](diffhunk://#diff-e2daabe2701622fb3eac5efc9d824c4039e40eca2c643e6fe0681aa676a06a44R1-R8) [[2]](diffhunk://#diff-06d13bfefcff0e7fafaa035b47cf6cd1290dddb316b74c3531d977464b3c90c7R1-R14) [[3]](diffhunk://#diff-d19d863e20cbb5baa640c6f689b0d5370652d469ab2b504267716877986fe44dR9) [[4]](diffhunk://#diff-d19d863e20cbb5baa640c6f689b0d5370652d469ab2b504267716877986fe44dR34-R35) [[5]](diffhunk://#diff-28d2534248fc7460376c48afb9c58621b49fe1664cb28acaf21f4196e1b4c575R11) [[6]](diffhunk://#diff-28d2534248fc7460376c48afb9c58621b49fe1664cb28acaf21f4196e1b4c575R21) [[7]](diffhunk://#diff-28d2534248fc7460376c48afb9c58621b49fe1664cb28acaf21f4196e1b4c575R48-R49) [[8]](diffhunk://#diff-28d2534248fc7460376c48afb9c58621b49fe1664cb28acaf21f4196e1b4c575R82-R84)

**API endpoints for notifications:**

* Added `NotificationsController` with endpoints to fetch notifications, get unread count, mark single or all notifications as read. (`CVision/Controllers/ApiControllers/NotificationsController.cs`)

**Real-time notification delivery:**

* Implemented `NotificationHub` using SignalR for real-time push notifications, and registered the hub route. (`CVision/Hubs/NotificationHub.cs`, `CVision/Program.cs`) [[1]](diffhunk://#diff-041eada87a324561dd3776da5a9ab28f0384ff6df799e0ba2cae7a1fc04bda50R1-R30) [[2]](diffhunk://#diff-032e1b4b96b636e5a22a775264581555bc297127adaaa4d9f2ebaa9b60574217R11-R15) [[3]](diffhunk://#diff-032e1b4b96b636e5a22a775264581555bc297127adaaa4d9f2ebaa9b60574217R62-R63) [[4]](diffhunk://#diff-032e1b4b96b636e5a22a775264581555bc297127adaaa4d9f2ebaa9b60574217R124) [[5]](diffhunk://#diff-eae72294c6012867cc4e5478f67981542172b88f9cee1e147c5725c1aaf02e0eR21)

**Background services:**

* Registered a `NotificationBackgroundService` for background processing of notifications. (`CVision/Program.cs`)

These changes together provide a robust infrastructure for user notifications, supporting both API-based access and real-time updates.